### PR TITLE
chore: configure custom domain (argent.photo)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# App URL — used for metadataBase (SEO canonical URLs, Open Graph)
+NEXT_PUBLIC_APP_URL=http://localhost:3000
+
 # Supabase - Required for cloud sync (Phase 2). App works fully offline without these.
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,9 @@ import { getLocale } from "next-intl/server";
 import "@/app/globals.css";
 
 export const metadata: Metadata = {
+  metadataBase: new URL(
+    process.env.NEXT_PUBLIC_APP_URL || "http://localhost:3000"
+  ),
   title: {
     default: "Argent — The film photographer's companion",
     template: "%s | Argent",


### PR DESCRIPTION
## Summary

Add `NEXT_PUBLIC_APP_URL` env var and `metadataBase` so SEO metadata resolves correctly on the custom domain.

## Related Issue

Closes #30

## Changes

- Add `metadataBase` to `app/layout.tsx` using `NEXT_PUBLIC_APP_URL` (falls back to `localhost:3000`)
- Add `NEXT_PUBLIC_APP_URL` to `.env.example`

## Manual steps after merge

- **Vercel**: Set `NEXT_PUBLIC_APP_URL=https://argent.photo` in environment variables
- **Supabase**: Set Site URL to `https://argent.photo` and add both `http://localhost:3000/**` and `https://argent.photo/**` to redirect URLs

## Checklist

- [x] Linked a GitHub issue above
- [x] All tests pass locally (`npm run typecheck && npm run lint && npm test`)
- [x] No new user-facing strings