### PR TITLE
feat: add language toggle and fix default locale redirect

### DIFF
--- a/app/[locale]/(marketing)/layout.tsx
+++ b/app/[locale]/(marketing)/layout.tsx
@@ -2,6 +2,7 @@ import { setRequestLocale, getTranslations } from "next-intl/server";
 import Link from "next/link";
 import { Logo } from "@/components/logo";
 import { SkipLink } from "@/components/skip-link";
+import { LocaleToggle } from "@/components/marketing/locale-toggle";
 
 export default async function MarketingLayout({
   children,
@@ -46,6 +47,7 @@ export default async function MarketingLayout({
             >
               {t("nav.signup")}
             </Link>
+            <LocaleToggle currentLocale={locale} />
           </div>
         </div>
       </header>

--- a/components/marketing/locale-toggle.tsx
+++ b/components/marketing/locale-toggle.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+export function LocaleToggle({ currentLocale }: { currentLocale: string }) {
+  const router = useRouter();
+  const isEnglish = currentLocale === "en";
+  const targetLocale = isEnglish ? "es" : "en";
+  const targetPath = isEnglish ? "/es" : "/";
+
+  function handleClick(e: React.MouseEvent<HTMLAnchorElement>) {
+    e.preventDefault();
+    document.cookie = `NEXT_LOCALE=${targetLocale};path=/;max-age=31536000;SameSite=Lax`;
+    router.push(targetPath);
+  }
+
+  return (
+    <a
+      href={targetPath}
+      onClick={handleClick}
+      className="text-xs font-medium text-muted-foreground hover:text-foreground"
+    >
+      {targetLocale.toUpperCase()}
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary
- Fix auto-redirect to `/es` for first-time visitors: proxy now forces `Accept-Language: en` when no `NEXT_LOCALE` cookie is present
- Add `<LocaleToggle>` client component to the marketing header (after Sign Up CTA) that sets the `NEXT_LOCALE` cookie and navigates to the alternate locale

Closes #32

## Test plan
- [ ] Clear cookies, visit `/` — should show English (no redirect to `/es`)
- [ ] Click "ES" in header — navigates to `/es`, sets `NEXT_LOCALE=es` cookie
- [ ] Reload `/` — redirects to `/es` (cookie preference respected)
- [ ] Click "EN" — navigates to `/`, sets `NEXT_LOCALE=en` cookie
- [ ] Visit `/es` directly (no cookie) — shows Spanish (explicit URL choice)
- [ ] CI passes (typecheck + lint + unit tests + E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)