### PR TITLE
feat: add user-uploadable profile avatars

### DIFF
--- a/app/(app)/layout.tsx
+++ b/app/(app)/layout.tsx
@@ -7,7 +7,7 @@ import { SidebarNav } from "@/components/sidebar-nav";
 import { Toaster } from "@/components/ui/sonner";
 import { Logo } from "@/components/logo";
 import { SyncStatus } from "@/components/sync-status";
-import { UserMenu } from "@/components/user-menu";
+import { UserMenuWithAvatar } from "@/components/user-menu-with-avatar";
 import { SkipLink } from "@/components/skip-link";
 import { createClient } from "@/lib/supabase/server";
 
@@ -41,7 +41,7 @@ export default async function AppLayout({
   }
 
   const userMenu = user ? (
-    <UserMenu
+    <UserMenuWithAvatar
       userId={user.id}
       email={user.email ?? ""}
       tier={tier}

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,6 +103,27 @@
   }
 }
 
+/*
+ * Pointer cursor for interactive elements.
+ *
+ * Tailwind v4 Preflight sets cursor:default on <button>.
+ * shadcn/ui components apply cursor-default (utilities layer) on menu/select items.
+ *
+ * Unlayered CSS beats ALL @layer rules in the CSS cascade, so this
+ * overrides both Preflight (base layer) and utilities (cursor-default).
+ */
+button:not(:disabled),
+[role="button"]:not([aria-disabled="true"]),
+[role="menuitem"],
+[role="menuitemcheckbox"],
+[role="menuitemradio"],
+[role="option"]:not([aria-disabled="true"]),
+[role="tab"]:not([aria-disabled="true"]),
+select:not(:disabled),
+summary {
+  cursor: pointer;
+}
+
 /* Leatherette texture overlay for marketing sections */
 .leatherette {
   position: relative;

--- a/components/settings/settings-content.test.tsx
+++ b/components/settings/settings-content.test.tsx
@@ -56,6 +56,20 @@ vi.mock("@/components/upgrade-prompt", () => ({
   UpgradePrompt: () => <div data-testid="upgrade-prompt" />,
 }));
 
+vi.mock("@/lib/avatar", () => ({
+  getLocalAvatar: vi.fn().mockResolvedValue(null),
+  setLocalAvatar: vi.fn().mockResolvedValue(undefined),
+  uploadAvatar: vi.fn().mockResolvedValue("user-123/avatar.jpg"),
+}));
+
+vi.mock("@/lib/user-avatar", () => ({
+  getUserAvatar: () => ({
+    icon: "camera" as const,
+    bgColor: "bg-[#F2B5A7]",
+    iconColor: "text-[#6B2A1A]",
+  }),
+}));
+
 import { SettingsContent } from "./settings-content";
 
 describe("SettingsContent", () => {
@@ -100,5 +114,14 @@ describe("SettingsContent", () => {
     mockQueryResults.push(undefined);
     render(<SettingsContent />);
     expect(screen.getByText("about")).toBeDefined();
+  });
+
+  it("renders avatar button with changeAvatar label", async () => {
+    mockQueryResults.push(undefined);
+    render(<SettingsContent />);
+    // Account card renders after async getUser resolves
+    const { findByLabelText } = screen;
+    const avatarBtn = await findByLabelText("changeAvatar");
+    expect(avatarBtn).toBeDefined();
   });
 });

--- a/components/user-menu-with-avatar.tsx
+++ b/components/user-menu-with-avatar.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import { useAvatar } from "@/hooks/useAvatar";
+import { UserMenu } from "@/components/user-menu";
+
+interface UserMenuWithAvatarProps {
+  userId: string;
+  email: string;
+  tier: "free" | "pro";
+  displayName?: string | null;
+}
+
+export function UserMenuWithAvatar(props: UserMenuWithAvatarProps) {
+  const avatarUrl = useAvatar();
+  return <UserMenu {...props} avatarUrl={avatarUrl} />;
+}

--- a/components/user-menu.test.tsx
+++ b/components/user-menu.test.tsx
@@ -49,4 +49,30 @@ describe("UserMenu", () => {
       screen.getByRole("button", { name: "John Doe" }),
     ).toBeDefined();
   });
+
+  it("renders avatar image when avatarUrl is provided", () => {
+    const { container } = render(
+      <UserMenu
+        userId="user-1"
+        email="test@example.com"
+        tier="free"
+        avatarUrl="blob:http://localhost/avatar"
+      />,
+    );
+    const img = container.querySelector("img");
+    expect(img).not.toBeNull();
+    expect(img!.getAttribute("src")).toBe("blob:http://localhost/avatar");
+  });
+
+  it("does not render img when avatarUrl is null", () => {
+    const { container } = render(
+      <UserMenu
+        userId="user-1"
+        email="test@example.com"
+        tier="free"
+        avatarUrl={null}
+      />,
+    );
+    expect(container.querySelector("img")).toBeNull();
+  });
 });

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -28,9 +28,10 @@ interface UserMenuProps {
   email: string;
   tier: "free" | "pro";
   displayName?: string | null;
+  avatarUrl?: string | null;
 }
 
-export function UserMenu({ userId, email, tier, displayName }: UserMenuProps) {
+export function UserMenu({ userId, email, tier, displayName, avatarUrl }: UserMenuProps) {
   const t = useTranslations("settings");
   const tNav = useTranslations("nav");
   const tUpgrade = useTranslations("upgrade");
@@ -53,12 +54,20 @@ export function UserMenu({ userId, email, tier, displayName }: UserMenuProps) {
         <button
           type="button"
           className={cn(
-            "flex h-8 w-8 items-center justify-center rounded-full transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-            avatar.bgColor,
+            "flex h-8 w-8 items-center justify-center overflow-hidden rounded-full transition-opacity hover:opacity-80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+            !avatarUrl && avatar.bgColor,
           )}
           aria-label={displayName || email}
         >
-          <Icon className={cn("h-4 w-4", avatar.iconColor)} />
+          {avatarUrl ? (
+            <img
+              src={avatarUrl}
+              alt=""
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <Icon className={cn("h-4 w-4", avatar.iconColor)} />
+          )}
         </button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-56">

--- a/hooks/useAvatar.test.ts
+++ b/hooks/useAvatar.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+let mockAvatarBlob: Blob | null = null;
+
+vi.mock("@/lib/avatar", () => ({
+  getLocalAvatar: () => Promise.resolve(mockAvatarBlob),
+}));
+
+const revokeObjectURL = vi.fn();
+const createObjectURL = vi.fn().mockReturnValue("blob:mock-url");
+vi.stubGlobal("URL", {
+  ...URL,
+  createObjectURL,
+  revokeObjectURL,
+});
+
+import { useAvatar } from "./useAvatar";
+
+describe("useAvatar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAvatarBlob = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns null when no local avatar exists", async () => {
+    const { result } = renderHook(() => useAvatar());
+    await waitFor(() => {
+      expect(result.current).toBeNull();
+    });
+  });
+
+  it("returns object URL when avatar blob exists", async () => {
+    mockAvatarBlob = new Blob(["img"], { type: "image/jpeg" });
+
+    const { result } = renderHook(() => useAvatar());
+    await waitFor(() => {
+      expect(result.current).toBe("blob:mock-url");
+    });
+    expect(createObjectURL).toHaveBeenCalledWith(mockAvatarBlob);
+  });
+
+  it("revokes object URL on unmount", async () => {
+    mockAvatarBlob = new Blob(["img"], { type: "image/jpeg" });
+
+    const { result, unmount } = renderHook(() => useAvatar());
+    await waitFor(() => {
+      expect(result.current).toBe("blob:mock-url");
+    });
+
+    unmount();
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:mock-url");
+  });
+});

--- a/hooks/useAvatar.ts
+++ b/hooks/useAvatar.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { getLocalAvatar } from "@/lib/avatar";
+
+/**
+ * Loads the local avatar blob from IndexedDB and returns an object URL.
+ * Returns null when no avatar is stored. Cleans up the URL on unmount.
+ */
+export function useAvatar(): string | null {
+  const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
+
+  useEffect(() => {
+    let url: string | null = null;
+
+    getLocalAvatar().then((blob) => {
+      if (blob) {
+        url = URL.createObjectURL(blob);
+        setAvatarUrl(url);
+      }
+    });
+
+    return () => {
+      if (url) {
+        URL.revokeObjectURL(url);
+      }
+    };
+  }, []);
+
+  return avatarUrl;
+}

--- a/lib/avatar.test.ts
+++ b/lib/avatar.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGet = vi.fn();
+const mockPut = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock("@/lib/db", () => ({
+  db: {
+    _syncMeta: {
+      get: (...args: unknown[]) => mockGet(...args),
+      put: (...args: unknown[]) => mockPut(...args),
+      delete: (...args: unknown[]) => mockDelete(...args),
+    },
+  },
+}));
+
+vi.mock("@/lib/image-sync", () => ({
+  compressImage: vi.fn().mockResolvedValue(new Blob(["compressed"], { type: "image/jpeg" })),
+}));
+
+import {
+  getLocalAvatar,
+  setLocalAvatar,
+  removeLocalAvatar,
+  uploadAvatar,
+  downloadAvatar,
+} from "./avatar";
+
+describe("avatar helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getLocalAvatar", () => {
+    it("returns blob when stored", async () => {
+      const blob = new Blob(["img"], { type: "image/jpeg" });
+      mockGet.mockResolvedValue({ key: "avatarBlob", value: blob });
+
+      const result = await getLocalAvatar();
+      expect(result).toBe(blob);
+      expect(mockGet).toHaveBeenCalledWith("avatarBlob");
+    });
+
+    it("returns null when no avatar stored", async () => {
+      mockGet.mockResolvedValue(undefined);
+
+      const result = await getLocalAvatar();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("setLocalAvatar", () => {
+    it("stores blob in _syncMeta", async () => {
+      const blob = new Blob(["img"], { type: "image/jpeg" });
+      await setLocalAvatar(blob);
+      expect(mockPut).toHaveBeenCalledWith({
+        key: "avatarBlob",
+        value: blob,
+      });
+    });
+  });
+
+  describe("removeLocalAvatar", () => {
+    it("deletes from _syncMeta", async () => {
+      await removeLocalAvatar();
+      expect(mockDelete).toHaveBeenCalledWith("avatarBlob");
+    });
+  });
+
+  describe("uploadAvatar", () => {
+    it("compresses, uploads, and updates profile", async () => {
+      const blob = new Blob(["img"], { type: "image/jpeg" });
+      const mockUpload = vi.fn().mockResolvedValue({ error: null });
+      const mockUpdate = vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      });
+      const supabase = {
+        storage: {
+          from: () => ({ upload: mockUpload }),
+        },
+        from: () => ({ update: mockUpdate }),
+      };
+
+      const result = await uploadAvatar(
+        supabase as never,
+        "user-123",
+        blob,
+      );
+
+      expect(result).toBe("user-123/avatar.jpg");
+      expect(mockUpload).toHaveBeenCalledWith(
+        "user-123/avatar.jpg",
+        expect.any(Blob),
+        { contentType: "image/jpeg", upsert: true },
+      );
+    });
+
+    it("returns null on upload error", async () => {
+      const blob = new Blob(["img"], { type: "image/jpeg" });
+      const supabase = {
+        storage: {
+          from: () => ({
+            upload: vi.fn().mockResolvedValue({ error: { message: "fail" } }),
+          }),
+        },
+      };
+
+      const result = await uploadAvatar(supabase as never, "user-123", blob);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("downloadAvatar", () => {
+    it("downloads blob from storage", async () => {
+      const blob = new Blob(["img"], { type: "image/jpeg" });
+      const supabase = {
+        storage: {
+          from: () => ({
+            download: vi.fn().mockResolvedValue({ data: blob, error: null }),
+          }),
+        },
+      };
+
+      const result = await downloadAvatar(supabase as never, "user-123/avatar.jpg");
+      expect(result).toBe(blob);
+    });
+
+    it("returns null on download error", async () => {
+      const supabase = {
+        storage: {
+          from: () => ({
+            download: vi.fn().mockResolvedValue({ data: null, error: { message: "fail" } }),
+          }),
+        },
+      };
+
+      const result = await downloadAvatar(supabase as never, "user-123/avatar.jpg");
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/lib/avatar.ts
+++ b/lib/avatar.ts
@@ -1,0 +1,83 @@
+import { db } from "./db";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+const STORAGE_BUCKET = "reference-images";
+const AVATAR_META_KEY = "avatarBlob";
+
+/**
+ * Read the local avatar blob from IndexedDB (_syncMeta table).
+ */
+export async function getLocalAvatar(): Promise<Blob | null> {
+  const row = await db._syncMeta.get(AVATAR_META_KEY);
+  return (row?.value as unknown as Blob) ?? null;
+}
+
+/**
+ * Save an avatar blob to local IndexedDB.
+ */
+export async function setLocalAvatar(blob: Blob): Promise<void> {
+  await db._syncMeta.put({ key: AVATAR_META_KEY, value: blob as never });
+}
+
+/**
+ * Remove the local avatar blob from IndexedDB.
+ */
+export async function removeLocalAvatar(): Promise<void> {
+  await db._syncMeta.delete(AVATAR_META_KEY);
+}
+
+/**
+ * Compress and upload avatar to Supabase Storage, then update user_profiles.avatar_url.
+ * Returns the storage path on success, null on failure.
+ */
+export async function uploadAvatar(
+  supabase: SupabaseClient,
+  userId: string,
+  blob: Blob,
+): Promise<string | null> {
+  const { compressImage } = await import("./image-sync");
+  const compressed = await compressImage(blob, 256, 0.8);
+  const path = `${userId}/avatar.jpg`;
+
+  const { error: uploadError } = await supabase.storage
+    .from(STORAGE_BUCKET)
+    .upload(path, compressed, {
+      contentType: "image/jpeg",
+      upsert: true,
+    });
+
+  if (uploadError) {
+    console.warn("Avatar upload failed:", uploadError.message);
+    return null;
+  }
+
+  const { error: updateError } = await supabase
+    .from("user_profiles")
+    .update({ avatar_url: path })
+    .eq("id", userId);
+
+  if (updateError) {
+    console.warn("Avatar profile update failed:", updateError.message);
+  }
+
+  return path;
+}
+
+/**
+ * Download avatar blob from Supabase Storage.
+ */
+export async function downloadAvatar(
+  supabase: SupabaseClient,
+  avatarPath: string,
+): Promise<Blob | null> {
+  const { data, error } = await supabase.storage
+    .from(STORAGE_BUCKET)
+    .download(avatarPath);
+
+  if (error || !data) {
+    console.warn("Avatar download failed:", error?.message);
+    return null;
+  }
+
+  return data;
+}

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -222,6 +222,7 @@ export const userProfileSchema = z.object({
   copyright_notice: z.string().max(200).nullable().optional(),
   default_metering: z.enum(METERING_MODES).nullable().optional(),
   default_camera_id: ulid.nullable().optional(),
+  avatar_url: z.string().max(500).nullable().optional(),
   updated_at: timestamp,
   created_at: timestamp,
 });

--- a/messages/en.json
+++ b/messages/en.json
@@ -285,7 +285,9 @@
     "tierPro": "Pro",
     "signOut": "Sign Out",
     "signedOut": "You have been signed out.",
-    "subscription": "Subscription"
+    "subscription": "Subscription",
+    "changeAvatar": "Change Avatar",
+    "avatarError": "Failed to update avatar"
   },
   "upgrade": {
     "title": "Upgrade to Pro",

--- a/messages/es.json
+++ b/messages/es.json
@@ -285,7 +285,9 @@
     "tierPro": "Pro",
     "signOut": "Cerrar Sesión",
     "signedOut": "Has cerrado sesión.",
-    "subscription": "Suscripción"
+    "subscription": "Suscripción",
+    "changeAvatar": "Cambiar Avatar",
+    "avatarError": "Error al actualizar el avatar"
   },
   "upgrade": {
     "title": "Mejora a Pro",

--- a/supabase/migrations/20260213000000_add_avatar_url.sql
+++ b/supabase/migrations/20260213000000_add_avatar_url.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_profiles ADD COLUMN avatar_url text;


### PR DESCRIPTION
## Summary
- Users can upload a profile photo from Settings → Account (clickable avatar circle with camera overlay)
- Avatar stored locally in IndexedDB for offline use, synced to Supabase Storage when online
- Avatar displays in the UserMenu trigger (top-right / sidebar)
- Adds `avatar_url` column to `user_profiles` via migration
- Fixes `cursor: pointer` on all interactive elements (buttons, selects, menu items) — Tailwind v4 Preflight sets `cursor: default` on buttons, and shadcn/ui applies `cursor-default` utility on menu/select items

Closes #34

## Test plan
- [ ] `npm run typecheck && npm run lint && npm test` — all pass (742 tests)
- [ ] Go to Settings → Account card shows clickable avatar circle
- [ ] Click avatar → file picker opens, select image → preview updates
- [ ] Avatar appears in UserMenu (top-right / sidebar)
- [ ] Reload page → avatar persists (loaded from local IndexedDB)
- [ ] With network: avatar syncs to Supabase Storage
- [ ] Cursor pointer shows on buttons, selects, dropdown menu items

🤖 Generated with [Claude Code](https://claude.com/claude-code)