### PR TITLE
fix: add Toaster to auth layout for signup/reset feedback

### DIFF
--- a/app/(auth)/layout.tsx
+++ b/app/(auth)/layout.tsx
@@ -1,6 +1,7 @@
 import { NextIntlClientProvider } from "next-intl";
 import { getLocale, getMessages } from "next-intl/server";
 import { SkipLink } from "@/components/skip-link";
+import { Toaster } from "@/components/ui/sonner";
 
 export default async function AuthLayout({
   children,
@@ -16,6 +17,7 @@ export default async function AuthLayout({
       <main id="main-content" className="flex min-h-screen items-center justify-center px-4">
         {children}
       </main>
+      <Toaster />
     </NextIntlClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Add missing `<Toaster />` component to the auth layout
- Toast notifications from signup, login, and password reset were silently discarded because Sonner's Toaster was only mounted in the app layout, not the auth layout

## Test plan
- [ ] Sign up with a new email — should see "Check your email for a confirmation link" toast
- [ ] Try login with wrong password — should see error toast
- [ ] Reset password — should see confirmation toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)