### PR TITLE
feat: account deletion with confirmation and data cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,8 @@ NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
 
 # Supabase Service Role - Server-only, never expose to client
-# SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+# Required for admin operations (account deletion)
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
 
 # Resend — transactional emails (auth confirmations, welcome)
 RESEND_API_KEY=re_your_key_here

--- a/app/api/account/delete/route.test.ts
+++ b/app/api/account/delete/route.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetUser = vi.fn();
+const mockSignOut = vi.fn();
+
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () =>
+    Promise.resolve({
+      auth: {
+        getUser: mockGetUser,
+        signOut: mockSignOut,
+      },
+    }),
+}));
+
+const mockAdminDeleteUser = vi.fn();
+const mockStorageList = vi.fn();
+const mockStorageRemove = vi.fn();
+const mockAdminFrom = vi.fn();
+
+vi.mock("@/lib/supabase/admin", () => ({
+  createAdminClient: () => ({
+    auth: { admin: { deleteUser: mockAdminDeleteUser } },
+    storage: {
+      from: (bucket: string) => {
+        mockAdminFrom(bucket);
+        return {
+          list: mockStorageList,
+          remove: mockStorageRemove,
+        };
+      },
+    },
+  }),
+}));
+
+let mockLocaleCookie: string | undefined = undefined;
+
+vi.mock("next/headers", () => ({
+  cookies: () =>
+    Promise.resolve({
+      get: (name: string) =>
+        name === "NEXT_LOCALE" && mockLocaleCookie
+          ? { value: mockLocaleCookie }
+          : undefined,
+    }),
+}));
+
+const mockSendEmail = vi.fn();
+
+vi.mock("@/lib/email/send-account-deleted", () => ({
+  sendAccountDeletedEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+import { POST } from "./route";
+
+function makeRequest(body: Record<string, unknown>) {
+  return new Request("http://localhost/api/account/delete", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/account/delete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLocaleCookie = undefined;
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-123", email: "test@example.com" } },
+    });
+    mockAdminDeleteUser.mockResolvedValue({ error: null });
+    mockStorageList.mockResolvedValue({ data: [], error: null });
+    mockStorageRemove.mockResolvedValue({ error: null });
+    mockSendEmail.mockResolvedValue(undefined);
+    mockSignOut.mockResolvedValue({ error: null });
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+
+    const res = await POST(makeRequest({ confirmation: "test@example.com" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(401);
+    expect(json.error).toBe("unauthenticated");
+  });
+
+  it("returns 400 when confirmation does not match email", async () => {
+    const res = await POST(makeRequest({ confirmation: "wrong@example.com" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(json.error).toBe("confirmationMismatch");
+  });
+
+  it("sends deletion email with default English locale", async () => {
+    await POST(makeRequest({ confirmation: "test@example.com" }));
+
+    expect(mockSendEmail).toHaveBeenCalledWith({
+      email: "test@example.com",
+      locale: "en",
+    });
+  });
+
+  it("sends deletion email with Spanish locale from cookie", async () => {
+    mockLocaleCookie = "es";
+    await POST(makeRequest({ confirmation: "test@example.com" }));
+
+    expect(mockSendEmail).toHaveBeenCalledWith({
+      email: "test@example.com",
+      locale: "es",
+    });
+  });
+
+  it("deletes storage files for the user", async () => {
+    mockStorageList.mockResolvedValue({
+      data: [{ name: "avatar.jpg" }, { name: "photo1.jpg" }],
+      error: null,
+    });
+
+    await POST(makeRequest({ confirmation: "test@example.com" }));
+
+    expect(mockAdminFrom).toHaveBeenCalledWith("reference-images");
+    expect(mockStorageList).toHaveBeenCalledWith("user-123");
+    expect(mockStorageRemove).toHaveBeenCalledWith([
+      "user-123/avatar.jpg",
+      "user-123/photo1.jpg",
+    ]);
+  });
+
+  it("skips storage removal when no files exist", async () => {
+    mockStorageList.mockResolvedValue({ data: [], error: null });
+
+    await POST(makeRequest({ confirmation: "test@example.com" }));
+
+    expect(mockStorageRemove).not.toHaveBeenCalled();
+  });
+
+  it("deletes the auth user via admin client", async () => {
+    await POST(makeRequest({ confirmation: "test@example.com" }));
+
+    expect(mockAdminDeleteUser).toHaveBeenCalledWith("user-123");
+  });
+
+  it("returns success on successful deletion", async () => {
+    const res = await POST(makeRequest({ confirmation: "test@example.com" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+  });
+
+  it("returns 500 when user deletion fails", async () => {
+    mockAdminDeleteUser.mockResolvedValue({
+      error: { message: "deletion failed" },
+    });
+
+    const res = await POST(makeRequest({ confirmation: "test@example.com" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(500);
+    expect(json.error).toBe("deletionFailed");
+  });
+
+  it("continues deletion even if email sending fails", async () => {
+    mockSendEmail.mockRejectedValue(new Error("email failed"));
+
+    const res = await POST(makeRequest({ confirmation: "test@example.com" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockAdminDeleteUser).toHaveBeenCalledWith("user-123");
+  });
+
+  it("continues deletion even if storage cleanup fails", async () => {
+    mockStorageList.mockResolvedValue({
+      data: null,
+      error: { message: "list failed" },
+    });
+
+    const res = await POST(makeRequest({ confirmation: "test@example.com" }));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(mockAdminDeleteUser).toHaveBeenCalledWith("user-123");
+  });
+});

--- a/app/api/account/delete/route.ts
+++ b/app/api/account/delete/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from "next/server";
+import { cookies } from "next/headers";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { sendAccountDeletedEmail } from "@/lib/email/send-account-deleted";
+import type { EmailLocale } from "@/lib/email/templates/types";
+
+export async function POST(request: Request) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user?.email) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+
+  const { confirmation } = await request.json();
+
+  if (confirmation !== user.email) {
+    return NextResponse.json(
+      { error: "confirmationMismatch" },
+      { status: 400 },
+    );
+  }
+
+  const admin = createAdminClient();
+
+  // Detect user locale from cookie
+  const cookieStore = await cookies();
+  const locale = (cookieStore.get("NEXT_LOCALE")?.value === "es" ? "es" : "en") as EmailLocale;
+
+  // Send deletion email before deleting (so it actually delivers)
+  try {
+    await sendAccountDeletedEmail({ email: user.email, locale });
+  } catch (e) {
+    console.error("[account-delete] Email failed:", e);
+  }
+
+  // Clean up storage files
+  try {
+    const { data: files } = await admin.storage
+      .from("reference-images")
+      .list(user.id);
+
+    if (files && files.length > 0) {
+      const paths = files.map((f) => `${user.id}/${f.name}`);
+      await admin.storage.from("reference-images").remove(paths);
+    }
+  } catch (e) {
+    console.error("[account-delete] Storage cleanup failed:", e);
+  }
+
+  // Delete auth user (CASCADE deletes all DB rows)
+  const { error } = await admin.auth.admin.deleteUser(user.id);
+
+  if (error) {
+    return NextResponse.json({ error: "deletionFailed" }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/components/settings/delete-account-section.test.tsx
+++ b/components/settings/delete-account-section.test.tsx
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const mockPush = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+let mockUserEmail: string | null = "test@example.com";
+vi.mock("@/lib/supabase/client", () => ({
+  createClient: () => ({
+    auth: {
+      getUser: () =>
+        Promise.resolve({
+          data: { user: mockUserEmail ? { email: mockUserEmail } : null },
+        }),
+      signOut: vi.fn().mockResolvedValue({ error: null }),
+    },
+  }),
+}));
+
+const mockDbDelete = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/db", () => ({
+  db: { delete: () => mockDbDelete() },
+}));
+
+// Radix AlertDialog doesn't render portal content in jsdom — mock with simple divs
+vi.mock("@/components/ui/alert-dialog", () => {
+  const React = require("react");
+  return {
+    AlertDialog: ({ children, open, onOpenChange }: { children: React.ReactNode; open?: boolean; onOpenChange?: (v: boolean) => void }) =>
+      React.createElement("div", { "data-testid": "alert-dialog", "data-open": open, onClick: () => onOpenChange?.(!open) }, children),
+    AlertDialogTrigger: ({ children, ...props }: { children: React.ReactNode; asChild?: boolean }) =>
+      React.createElement("div", { "data-testid": "alert-dialog-trigger", ...props }, children),
+    AlertDialogContent: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", { "data-testid": "alert-dialog-content" }, children),
+    AlertDialogHeader: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    AlertDialogFooter: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("div", null, children),
+    AlertDialogTitle: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("h2", null, children),
+    AlertDialogDescription: ({ children }: { children: React.ReactNode }) =>
+      React.createElement("p", null, children),
+    AlertDialogCancel: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement("button", props, children),
+    AlertDialogAction: ({ children, ...props }: { children: React.ReactNode; disabled?: boolean; onClick?: () => void }) =>
+      React.createElement("button", props, children),
+  };
+});
+
+vi.mock("@/components/ui/button", () => {
+  const React = require("react");
+  return {
+    Button: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement("button", props, children),
+  };
+});
+
+vi.mock("@/components/ui/input", () => {
+  const React = require("react");
+  return {
+    Input: (props: React.InputHTMLAttributes<HTMLInputElement>) =>
+      React.createElement("input", props),
+  };
+});
+
+vi.mock("@/components/ui/label", () => {
+  const React = require("react");
+  return {
+    Label: ({ children, ...props }: { children: React.ReactNode }) =>
+      React.createElement("label", props, children),
+  };
+});
+
+import { DeleteAccountSection } from "./delete-account-section";
+import { toast } from "sonner";
+
+describe("DeleteAccountSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUserEmail = "test@example.com";
+    mockDbDelete.mockResolvedValue(undefined);
+    mockPush.mockClear();
+    global.fetch = vi.fn();
+    global.localStorage.clear();
+  });
+
+  it("renders delete account button", async () => {
+    render(<DeleteAccountSection />);
+    expect(screen.getByText("deleteAccountButton")).toBeDefined();
+  });
+
+  it("renders description text", () => {
+    render(<DeleteAccountSection />);
+    expect(screen.getByText("deleteAccountDescription")).toBeDefined();
+  });
+
+  it("renders confirmation dialog title", () => {
+    render(<DeleteAccountSection />);
+    expect(screen.getByText("deleteAccountConfirmTitle")).toBeDefined();
+  });
+
+  it("renders confirmation input label", () => {
+    render(<DeleteAccountSection />);
+    expect(screen.getByText("deleteAccountConfirmLabel")).toBeDefined();
+  });
+
+  it("disables confirm button when input does not match email", () => {
+    render(<DeleteAccountSection />);
+    const confirmBtn = screen.getByText("deleteAccount");
+    expect(confirmBtn).toHaveProperty("disabled", true);
+  });
+
+  it("enables confirm button when input matches email", async () => {
+    render(<DeleteAccountSection />);
+
+    const input = screen.getByPlaceholderText("deleteAccountConfirmPlaceholder");
+    fireEvent.change(input, { target: { value: "test@example.com" } });
+
+    await waitFor(() => {
+      const confirmBtn = screen.getByText("deleteAccount");
+      expect(confirmBtn).toHaveProperty("disabled", false);
+    });
+  });
+
+  it("calls API and cleans up on successful deletion", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true }),
+    });
+
+    render(<DeleteAccountSection />);
+
+    const input = screen.getByPlaceholderText("deleteAccountConfirmPlaceholder");
+    fireEvent.change(input, { target: { value: "test@example.com" } });
+
+    await waitFor(() => {
+      const confirmBtn = screen.getByText("deleteAccount");
+      expect(confirmBtn).toHaveProperty("disabled", false);
+    });
+
+    const confirmBtn = screen.getByText("deleteAccount");
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/account/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirmation: "test@example.com" }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockDbDelete).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/login");
+    });
+  });
+
+  it("shows error toast when API returns error", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ error: "deletionFailed" }),
+    });
+
+    render(<DeleteAccountSection />);
+
+    const input = screen.getByPlaceholderText("deleteAccountConfirmPlaceholder");
+    fireEvent.change(input, { target: { value: "test@example.com" } });
+
+    await waitFor(() => {
+      const confirmBtn = screen.getByText("deleteAccount");
+      expect(confirmBtn).toHaveProperty("disabled", false);
+    });
+
+    const confirmBtn = screen.getByText("deleteAccount");
+    fireEvent.click(confirmBtn);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("deleteAccountError");
+    });
+  });
+});

--- a/components/settings/delete-account-section.tsx
+++ b/components/settings/delete-account-section.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { useRouter } from "next/navigation";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { createClient } from "@/lib/supabase/client";
+import { db } from "@/lib/db";
+import { toast } from "sonner";
+
+export function DeleteAccountSection() {
+  const t = useTranslations("settings");
+  const router = useRouter();
+  const [userEmail, setUserEmail] = useState<string | null>(null);
+  const [confirmationText, setConfirmationText] = useState("");
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  useEffect(() => {
+    const supabase = createClient();
+    supabase.auth.getUser().then(({ data: { user } }) => {
+      setUserEmail(user?.email ?? null);
+    });
+  }, []);
+
+  const isConfirmed = confirmationText === userEmail;
+
+  async function handleDelete() {
+    if (!isConfirmed || !userEmail) return;
+
+    setIsDeleting(true);
+
+    try {
+      const res = await fetch("/api/account/delete", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ confirmation: confirmationText }),
+      });
+
+      if (!res.ok) {
+        toast.error(t("deleteAccountError"));
+        setIsDeleting(false);
+        return;
+      }
+
+      // Clear local data
+      await db.delete();
+      localStorage.clear();
+
+      // Redirect to login
+      router.push("/login");
+    } catch {
+      toast.error(t("deleteAccountError"));
+      setIsDeleting(false);
+    }
+  }
+
+  return (
+    <div className="mt-3">
+      <p className="text-sm text-muted-foreground">
+        {t("deleteAccountDescription")}
+      </p>
+
+      <AlertDialog open={dialogOpen} onOpenChange={(open) => {
+        setDialogOpen(open);
+        if (!open) {
+          setConfirmationText("");
+          setIsDeleting(false);
+        }
+      }}>
+        <AlertDialogTrigger asChild>
+          <Button variant="destructive" className="mt-3">
+            {t("deleteAccountButton")}
+          </Button>
+        </AlertDialogTrigger>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t("deleteAccountConfirmTitle")}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t("deleteAccountConfirmDescription")}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="space-y-2">
+            <Label htmlFor="delete-confirm">{t("deleteAccountConfirmLabel")}</Label>
+            <Input
+              id="delete-confirm"
+              value={confirmationText}
+              onChange={(e) => setConfirmationText(e.target.value)}
+              placeholder={t("deleteAccountConfirmPlaceholder")}
+              autoComplete="off"
+            />
+          </div>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t("cancel")}</AlertDialogCancel>
+            <AlertDialogAction
+              variant="destructive"
+              disabled={!isConfirmed || isDeleting}
+              onClick={handleDelete}
+            >
+              {isDeleting ? t("deleteAccountConfirming") : t("deleteAccount")}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/components/settings/settings-content.test.tsx
+++ b/components/settings/settings-content.test.tsx
@@ -56,6 +56,10 @@ vi.mock("@/components/upgrade-prompt", () => ({
   UpgradePrompt: () => <div data-testid="upgrade-prompt" />,
 }));
 
+vi.mock("./delete-account-section", () => ({
+  DeleteAccountSection: () => <div data-testid="delete-account-section" />,
+}));
+
 vi.mock("@/lib/avatar", () => ({
   getLocalAvatar: vi.fn().mockResolvedValue(null),
   setLocalAvatar: vi.fn().mockResolvedValue(undefined),

--- a/components/settings/settings-content.tsx
+++ b/components/settings/settings-content.tsx
@@ -24,6 +24,7 @@ import { getUserAvatar, type AvatarIcon } from "@/lib/user-avatar";
 import { Camera as CameraIcon, Aperture, Film as FilmIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
+import { DeleteAccountSection } from "./delete-account-section";
 
 const AVATAR_ICON_MAP = {
   camera: CameraIcon,
@@ -341,6 +342,14 @@ export function SettingsContent() {
           </SettingRow>
         </div>
       </div>
+
+      {/* Danger Zone */}
+      {userEmail && (
+        <div>
+          <SectionHeader>{t("dangerZone")}</SectionHeader>
+          <DeleteAccountSection />
+        </div>
+      )}
 
       <p className="text-sm text-muted-foreground">
         {t("about")} · {t("version")} 0.1.0

--- a/lib/email/send-account-deleted.test.ts
+++ b/lib/email/send-account-deleted.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockSendEmail = vi.fn();
+
+vi.mock("./client", () => ({
+  sendEmail: (...args: unknown[]) => mockSendEmail(...args),
+}));
+
+import { sendAccountDeletedEmail } from "./send-account-deleted";
+
+describe("sendAccountDeletedEmail", () => {
+  beforeEach(() => {
+    mockSendEmail.mockReset();
+    mockSendEmail.mockResolvedValue(undefined);
+  });
+
+  it("sends account deleted email with correct subject", async () => {
+    await sendAccountDeletedEmail({ email: "user@example.com" });
+
+    expect(mockSendEmail).toHaveBeenCalledWith({
+      to: "user@example.com",
+      subject: "Your Argent account has been deleted",
+      html: expect.stringContaining("Account Deleted"),
+    });
+  });
+
+  it("defaults to English locale", async () => {
+    await sendAccountDeletedEmail({ email: "user@example.com" });
+
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: "Your Argent account has been deleted",
+        html: expect.stringContaining("permanently deleted"),
+      }),
+    );
+  });
+
+  it("uses Spanish locale when specified", async () => {
+    await sendAccountDeletedEmail({ email: "user@example.com", locale: "es" });
+
+    expect(mockSendEmail).toHaveBeenCalledWith(
+      expect.objectContaining({
+        subject: "Tu cuenta de Argent ha sido eliminada",
+        html: expect.stringContaining("Cuenta Eliminada"),
+      }),
+    );
+  });
+});

--- a/lib/email/send-account-deleted.ts
+++ b/lib/email/send-account-deleted.ts
@@ -1,0 +1,14 @@
+import { sendEmail } from "./client";
+import { accountDeletedTemplate } from "./templates/account-deleted";
+import type { EmailLocale } from "./templates/types";
+
+export async function sendAccountDeletedEmail({
+  email,
+  locale = "en",
+}: {
+  email: string;
+  locale?: EmailLocale;
+}) {
+  const { subject, html } = accountDeletedTemplate({ email, locale });
+  await sendEmail({ to: email, subject, html });
+}

--- a/lib/email/templates/account-deleted.test.ts
+++ b/lib/email/templates/account-deleted.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { accountDeletedTemplate } from "./account-deleted";
+
+describe("accountDeletedTemplate", () => {
+  const defaultProps = {
+    email: "user@example.com",
+    locale: "en" as const,
+  };
+
+  it("returns subject and html", () => {
+    const result = accountDeletedTemplate(defaultProps);
+    expect(result.subject).toBe("Your Argent account has been deleted");
+    expect(result.html).toContain("<!DOCTYPE html>");
+  });
+
+  it("includes account deleted heading", () => {
+    const result = accountDeletedTemplate(defaultProps);
+    expect(result.html).toContain("Account Deleted");
+  });
+
+  it("includes deletion body text", () => {
+    const result = accountDeletedTemplate(defaultProps);
+    expect(result.html).toContain("permanently deleted");
+  });
+
+  it("includes contact information", () => {
+    const result = accountDeletedTemplate(defaultProps);
+    expect(result.html).toContain("support@argent.photo");
+  });
+
+  it("does not include any action buttons or links", () => {
+    const result = accountDeletedTemplate(defaultProps);
+    expect(result.html).not.toContain("class=\"btn\"");
+  });
+
+  it("renders Spanish when locale is es", () => {
+    const result = accountDeletedTemplate({ ...defaultProps, locale: "es" });
+    expect(result.subject).toBe("Tu cuenta de Argent ha sido eliminada");
+    expect(result.html).toContain("Cuenta Eliminada");
+  });
+});

--- a/lib/email/templates/account-deleted.ts
+++ b/lib/email/templates/account-deleted.ts
@@ -1,0 +1,21 @@
+import type { AccountDeletedProps } from "./types";
+import { getMessages } from "./messages";
+import { baseLayout, escapeHtml } from "./utils";
+
+export function accountDeletedTemplate(props: AccountDeletedProps) {
+  const { locale } = props;
+  const m = getMessages(locale).accountDeleted;
+
+  const content = `
+    <h1>${escapeHtml(m.heading)}</h1>
+    <p>${escapeHtml(m.body)}</p>
+    <hr class="divider">
+    <p style="font-size:14px;color:#a1a1aa;margin:0;">
+      ${escapeHtml(m.contact)}
+    </p>`;
+
+  return {
+    subject: m.subject,
+    html: baseLayout(content, locale),
+  };
+}

--- a/lib/email/templates/messages.ts
+++ b/lib/email/templates/messages.ts
@@ -40,6 +40,13 @@ const messages = {
         export: "Export XMP sidecar files to embed metadata into your scans",
       },
     },
+    accountDeleted: {
+      subject: "Your Argent account has been deleted",
+      heading: "Account Deleted",
+      body: "Your Argent account and all associated data have been permanently deleted. This includes your rolls, frames, gear, and any uploaded images.",
+      contact:
+        "If you didn't request this deletion, please contact support@argent.photo.",
+    },
     footer: {
       tagline: "The film photographer's companion",
       unsubscribe:
@@ -85,6 +92,13 @@ const messages = {
         export:
           "Exporta archivos XMP sidecar para incrustar metadatos en tus escaneos",
       },
+    },
+    accountDeleted: {
+      subject: "Tu cuenta de Argent ha sido eliminada",
+      heading: "Cuenta Eliminada",
+      body: "Tu cuenta de Argent y todos los datos asociados han sido eliminados permanentemente. Esto incluye tus rollos, fotogramas, equipo y cualquier imagen subida.",
+      contact:
+        "Si no solicitaste esta eliminación, contacta a support@argent.photo.",
     },
     footer: {
       tagline: "El compañero del fotógrafo analógico",

--- a/lib/email/templates/types.ts
+++ b/lib/email/templates/types.ts
@@ -20,6 +20,11 @@ export interface WelcomeProps {
   locale: EmailLocale;
 }
 
+export interface AccountDeletedProps {
+  email: string;
+  locale: EmailLocale;
+}
+
 export interface EmailTemplate<T> {
   subject: string;
   html: string;

--- a/lib/supabase/admin.test.ts
+++ b/lib/supabase/admin.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockCreateClient = vi.fn().mockReturnValue({ auth: { admin: {} } });
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: (...args: unknown[]) => mockCreateClient(...args),
+}));
+
+describe("createAdminClient", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.resetModules();
+    mockCreateClient.mockClear();
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_SUPABASE_URL: "https://test.supabase.co",
+      SUPABASE_SERVICE_ROLE_KEY: "test-service-role-key",
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it("creates a Supabase client with service role key", async () => {
+    const { createAdminClient } = await import("./admin");
+    createAdminClient();
+
+    expect(mockCreateClient).toHaveBeenCalledWith(
+      "https://test.supabase.co",
+      "test-service-role-key",
+      expect.objectContaining({
+        auth: expect.objectContaining({
+          autoRefreshToken: false,
+          persistSession: false,
+        }),
+      }),
+    );
+  });
+
+  it("throws when SUPABASE_SERVICE_ROLE_KEY is missing", async () => {
+    delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    const { createAdminClient } = await import("./admin");
+
+    expect(() => createAdminClient()).toThrow("SUPABASE_SERVICE_ROLE_KEY");
+  });
+});

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,0 +1,21 @@
+import { createClient } from "@supabase/supabase-js";
+
+export function createAdminClient() {
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!serviceRoleKey) {
+    throw new Error(
+      "SUPABASE_SERVICE_ROLE_KEY is not set. Required for admin operations.",
+    );
+  }
+
+  return createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    serviceRoleKey,
+    {
+      auth: {
+        autoRefreshToken: false,
+        persistSession: false,
+      },
+    },
+  );
+}

--- a/messages/en.json
+++ b/messages/en.json
@@ -289,7 +289,18 @@
     "changeAvatar": "Change Avatar",
     "avatarError": "Failed to update avatar",
     "preferences": "Preferences",
-    "metadata": "Metadata"
+    "metadata": "Metadata",
+    "dangerZone": "Danger Zone",
+    "deleteAccount": "Delete Account",
+    "deleteAccountDescription": "Permanently delete your account and all data. This cannot be undone.",
+    "deleteAccountButton": "Delete My Account",
+    "deleteAccountConfirmTitle": "Delete Account",
+    "deleteAccountConfirmDescription": "This will permanently delete your account and all associated data, including rolls, frames, cameras, lenses, and uploaded images. This action cannot be undone.",
+    "deleteAccountConfirmLabel": "Type your email to confirm",
+    "deleteAccountConfirmPlaceholder": "your@email.com",
+    "deleteAccountConfirming": "Deleting...",
+    "deleteAccountError": "Failed to delete account. Please try again.",
+    "cancel": "Cancel"
   },
   "upgrade": {
     "title": "Upgrade to Pro",

--- a/messages/es.json
+++ b/messages/es.json
@@ -289,7 +289,18 @@
     "changeAvatar": "Cambiar Avatar",
     "avatarError": "Error al actualizar el avatar",
     "preferences": "Preferencias",
-    "metadata": "Metadatos"
+    "metadata": "Metadatos",
+    "dangerZone": "Zona de Peligro",
+    "deleteAccount": "Eliminar Cuenta",
+    "deleteAccountDescription": "Elimina permanentemente tu cuenta y todos los datos. Esto no se puede deshacer.",
+    "deleteAccountButton": "Eliminar Mi Cuenta",
+    "deleteAccountConfirmTitle": "Eliminar Cuenta",
+    "deleteAccountConfirmDescription": "Esto eliminará permanentemente tu cuenta y todos los datos asociados, incluidos rollos, fotogramas, cámaras, lentes e imágenes subidas. Esta acción no se puede deshacer.",
+    "deleteAccountConfirmLabel": "Escribe tu correo electrónico para confirmar",
+    "deleteAccountConfirmPlaceholder": "tu@correo.com",
+    "deleteAccountConfirming": "Eliminando...",
+    "deleteAccountError": "Error al eliminar la cuenta. Inténtalo de nuevo.",
+    "cancel": "Cancelar"
   },
   "upgrade": {
     "title": "Mejora a Pro",


### PR DESCRIPTION
## Summary

- Add "Danger Zone" section to Settings with type-to-confirm account deletion dialog
- Create `POST /api/account/delete` API route using Supabase service role key
- Rely on `ON DELETE CASCADE` from `auth.users` to clean up all DB tables automatically
- Clean up Supabase Storage files (`reference-images/{userId}/*`) before deletion
- Send locale-aware confirmation email via Resend (reads `NEXT_LOCALE` cookie)
- Client-side cleanup: clear IndexedDB (`db.delete()`), localStorage, redirect to `/login`
- Add admin Supabase client (`lib/supabase/admin.ts`) for service role operations
- Add i18n keys for both English and Spanish

Closes #39

## Test plan

- [x] 30 new unit tests across 5 test files (838 total, all passing)
- [x] TypeScript strict mode passes
- [x] ESLint passes
- [ ] Manual test: create account → verify → delete → confirm data gone → sign up again
- [ ] Verify `SUPABASE_SERVICE_ROLE_KEY` is set in Vercel env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)