### PR TITLE
fix: scope avatar blob by user ID to prevent cross-user leakage

### DIFF
--- a/components/settings/settings-content.tsx
+++ b/components/settings/settings-content.tsx
@@ -88,14 +88,19 @@ export function SettingsContent() {
       if (cr) setCopyright(cr);
       const dm = await getSetting("defaultMetering");
       setDefaultMetering(dm || "__none__");
-
-      const blob = await getLocalAvatar();
-      if (blob) {
-        setAvatarUrl(URL.createObjectURL(blob));
-      }
     }
     load();
   }, []);
+
+  // Load avatar (scoped to user)
+  useEffect(() => {
+    if (!userId) return;
+    getLocalAvatar(userId).then((blob) => {
+      if (blob) {
+        setAvatarUrl(URL.createObjectURL(blob));
+      }
+    });
+  }, [userId]);
 
   const cameras = useLiveQuery(
     () => {
@@ -145,7 +150,7 @@ export function SettingsContent() {
       }
 
       // Save locally
-      await setLocalAvatar(result.blob);
+      await setLocalAvatar(userId!, result.blob);
       if (avatarUrl) URL.revokeObjectURL(avatarUrl);
       setAvatarUrl(URL.createObjectURL(result.blob));
 

--- a/components/user-menu-with-avatar.tsx
+++ b/components/user-menu-with-avatar.tsx
@@ -11,6 +11,6 @@ interface UserMenuWithAvatarProps {
 }
 
 export function UserMenuWithAvatar(props: UserMenuWithAvatarProps) {
-  const avatarUrl = useAvatar();
+  const avatarUrl = useAvatar(props.userId);
   return <UserMenu {...props} avatarUrl={avatarUrl} />;
 }

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -14,6 +14,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { getUserAvatar, type AvatarIcon } from "@/lib/user-avatar";
 import { signOut, joinWaitlist } from "@/app/(app)/settings/actions";
+import { clearGlobalAvatarKey } from "@/lib/avatar";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 
@@ -93,7 +94,10 @@ export function UserMenu({ userId, email, tier, displayName, avatarUrl }: UserMe
           </DropdownMenuItem>
         )}
         <DropdownMenuItem
-          onSelect={() => startTransition(() => signOut())}
+          onSelect={() => startTransition(async () => {
+            await clearGlobalAvatarKey();
+            await signOut();
+          })}
           disabled={pending}
         >
           <LogOut className="h-4 w-4" />

--- a/hooks/useAvatar.test.ts
+++ b/hooks/useAvatar.test.ts
@@ -1,10 +1,12 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { renderHook, act, waitFor } from "@testing-library/react";
+import { renderHook, waitFor } from "@testing-library/react";
 
 let mockAvatarBlob: Blob | null = null;
+const mockMigrateGlobalAvatar = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("@/lib/avatar", () => ({
   getLocalAvatar: () => Promise.resolve(mockAvatarBlob),
+  migrateGlobalAvatar: (...args: unknown[]) => mockMigrateGlobalAvatar(...args),
 }));
 
 const revokeObjectURL = vi.fn();
@@ -27,27 +29,37 @@ describe("useAvatar", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns null when no local avatar exists", async () => {
-    const { result } = renderHook(() => useAvatar());
+  it("returns null when userId is null", async () => {
+    const { result } = renderHook(() => useAvatar(null));
     await waitFor(() => {
       expect(result.current).toBeNull();
     });
+    expect(mockMigrateGlobalAvatar).not.toHaveBeenCalled();
+  });
+
+  it("returns null when no local avatar exists", async () => {
+    const { result } = renderHook(() => useAvatar("user-123"));
+    await waitFor(() => {
+      expect(result.current).toBeNull();
+    });
+    expect(mockMigrateGlobalAvatar).toHaveBeenCalledWith("user-123");
   });
 
   it("returns object URL when avatar blob exists", async () => {
     mockAvatarBlob = new Blob(["img"], { type: "image/jpeg" });
 
-    const { result } = renderHook(() => useAvatar());
+    const { result } = renderHook(() => useAvatar("user-123"));
     await waitFor(() => {
       expect(result.current).toBe("blob:mock-url");
     });
     expect(createObjectURL).toHaveBeenCalledWith(mockAvatarBlob);
+    expect(mockMigrateGlobalAvatar).toHaveBeenCalledWith("user-123");
   });
 
   it("revokes object URL on unmount", async () => {
     mockAvatarBlob = new Blob(["img"], { type: "image/jpeg" });
 
-    const { result, unmount } = renderHook(() => useAvatar());
+    const { result, unmount } = renderHook(() => useAvatar("user-123"));
     await waitFor(() => {
       expect(result.current).toBe("blob:mock-url");
     });

--- a/hooks/useAvatar.ts
+++ b/hooks/useAvatar.ts
@@ -1,31 +1,39 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { getLocalAvatar } from "@/lib/avatar";
+import { getLocalAvatar, migrateGlobalAvatar } from "@/lib/avatar";
 
 /**
  * Loads the local avatar blob from IndexedDB and returns an object URL.
- * Returns null when no avatar is stored. Cleans up the URL on unmount.
+ * Returns null when no avatar is stored or userId is null.
+ * Migrates the old global key on first load, then reads the user-scoped key.
+ * Cleans up the URL on unmount.
  */
-export function useAvatar(): string | null {
+export function useAvatar(userId: string | null): string | null {
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!userId) return;
+
     let url: string | null = null;
 
-    getLocalAvatar().then((blob) => {
+    async function load() {
+      await migrateGlobalAvatar(userId!);
+      const blob = await getLocalAvatar(userId!);
       if (blob) {
         url = URL.createObjectURL(blob);
         setAvatarUrl(url);
       }
-    });
+    }
+
+    load();
 
     return () => {
       if (url) {
         URL.revokeObjectURL(url);
       }
     };
-  }, []);
+  }, [userId]);
 
   return avatarUrl;
 }

--- a/hooks/useSync.ts
+++ b/hooks/useSync.ts
@@ -80,7 +80,7 @@ export function useSync(userId: string | null, options?: UseSyncOptions): UseSyn
           "@/lib/settings-helpers"
         );
 
-        const localAvatar = await getLocalAvatar();
+        const localAvatar = await getLocalAvatar(userId);
         const avatarUploaded = await getSetting("avatarUploaded");
 
         if (localAvatar && avatarUploaded !== "true") {
@@ -100,7 +100,7 @@ export function useSync(userId: string | null, options?: UseSyncOptions): UseSyn
           if (profile?.avatar_url) {
             const blob = await downloadAvatar(supabase, profile.avatar_url);
             if (blob) {
-              await setLocalAvatar(blob);
+              await setLocalAvatar(userId, blob);
               await setSetting("avatarUploaded", "true");
             }
           }


### PR DESCRIPTION
## Summary

Closes #44

- Scoped avatar blob storage key in IndexedDB from global `avatarBlob` to `avatarBlob:${userId}`, preventing one user's avatar from appearing on another account in the same browser
- Added `migrateGlobalAvatar()` to auto-migrate the old global key to the user-scoped key on first load
- Added `clearGlobalAvatarKey()` called on sign-out to prevent leakage between sessions
- Updated all call sites: `useAvatar`, `useSync`, `settings-content`, `user-menu-with-avatar`, `user-menu`

## Files changed (8)

- `lib/avatar.ts` — Added `userId` param to `getLocalAvatar`/`setLocalAvatar`/`removeLocalAvatar`, added `migrateGlobalAvatar()` and `clearGlobalAvatarKey()`
- `lib/avatar.test.ts` — Added 5 new tests for migration and global key cleanup
- `hooks/useAvatar.ts` — Takes `userId` param, calls `migrateGlobalAvatar` on mount
- `hooks/useAvatar.test.ts` — Updated for `userId` param and migration mock
- `hooks/useSync.ts` — Pass `userId` to `getLocalAvatar`/`setLocalAvatar`
- `components/settings/settings-content.tsx` — Split avatar load into user-scoped `useEffect`, pass `userId` to `setLocalAvatar`
- `components/user-menu-with-avatar.tsx` — Pass `userId` to `useAvatar`
- `components/user-menu.tsx` — Call `clearGlobalAvatarKey()` before sign-out

## Test plan

- [x] All 844 unit tests pass
- [x] TypeScript strict mode passes
- [x] ESLint passes
- [ ] Manual: Sign in as User A, upload avatar, sign out, sign in as User B — User B should not see User A's avatar
- [ ] Manual: Existing users with old global key get avatar migrated automatically on login

🤖 Generated with [Claude Code](https://claude.com/claude-code)