### PR TITLE
fix: use static import for image-capture to preserve iOS gesture chain

### DIFF
--- a/components/roll/shot-logger.tsx
+++ b/components/roll/shot-logger.tsx
@@ -47,6 +47,7 @@ import { cn } from "@/lib/utils";
 import { LiveRegion } from "@/components/live-region";
 import { isZoomLens, formatFocalLength, defaultFrameFocalLength } from "@/lib/lens-utils";
 import type { Roll, Frame, Lens, MeteringMode } from "@/lib/types";
+import { captureImage } from "@/lib/image-capture";
 import { toast } from "sonner";
 
 interface ShotLoggerProps {
@@ -227,7 +228,8 @@ export function ShotLogger({ roll }: ShotLoggerProps) {
   // ----- Image capture handlers -----
 
   async function captureWithErrorHandling(): Promise<Blob | null> {
-    const { captureImage } = await import("@/lib/image-capture");
+    // captureImage is statically imported — dynamic import here would break
+    // the iOS Safari user-gesture chain before input.click().
     const result = await captureImage();
     if ("error" in result) {
       if (result.error !== "no_file") {

--- a/components/settings/settings-content.test.tsx
+++ b/components/settings/settings-content.test.tsx
@@ -60,6 +60,11 @@ vi.mock("./delete-account-section", () => ({
   DeleteAccountSection: () => <div data-testid="delete-account-section" />,
 }));
 
+const mockCaptureImage = vi.fn();
+vi.mock("@/lib/image-capture", () => ({
+  captureImage: (...args: unknown[]) => mockCaptureImage(...args),
+}));
+
 vi.mock("@/lib/avatar", () => ({
   getLocalAvatar: vi.fn().mockResolvedValue(null),
   setLocalAvatar: vi.fn().mockResolvedValue(undefined),
@@ -82,6 +87,7 @@ describe("SettingsContent", () => {
     queryCallIndex = 0;
     mockQueryResults.length = 0;
     mockUserId = "user-123";
+    mockCaptureImage.mockResolvedValue({ error: "no_file" });
   });
 
   it("renders language setting row", () => {

--- a/components/settings/settings-content.tsx
+++ b/components/settings/settings-content.tsx
@@ -23,6 +23,7 @@ import { getLocalAvatar, setLocalAvatar, uploadAvatar } from "@/lib/avatar";
 import { getUserAvatar, type AvatarIcon } from "@/lib/user-avatar";
 import { Camera as CameraIcon, Aperture, Film as FilmIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { captureImage } from "@/lib/image-capture";
 import { toast } from "sonner";
 import { DeleteAccountSection } from "./delete-account-section";
 
@@ -140,7 +141,8 @@ export function SettingsContent() {
 
   async function handleAvatarChange() {
     try {
-      const { captureImage } = await import("@/lib/image-capture");
+      // captureImage is statically imported — dynamic import here would break
+      // the iOS Safari user-gesture chain before input.click().
       const result = await captureImage(256, 0.8);
       if ("error" in result) {
         if (result.error !== "no_file") {


### PR DESCRIPTION
## Summary

- Switches `image-capture` from dynamic `await import()` to static import in shot-logger and settings-content, fixing iOS Safari/Chrome/PWA silently blocking `input.click()` on file inputs when called after an async gap in the user-gesture chain
- Adds exporter chunk preloading via `useEffect` in export dialog to reduce await depth before `navigator.share()` on iOS
- Adds test coverage for the camera button click path in shot-logger and proper `image-capture` mocks in both test files

Closes #52

## Test plan

- [x] All 855 unit tests pass
- [x] TypeScript typecheck clean
- [x] ESLint clean
- [ ] Manual: file picker opens on iOS Safari (in-browser)
- [ ] Manual: file picker opens on iOS Chrome
- [ ] Manual: file picker opens on iOS PWA standalone mode
- [ ] Manual: avatar picker works in Settings on iOS
- [ ] Manual: no regression on desktop browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)