### PR TITLE
fix: wire up next-themes and fix chart colors for Tailwind v4

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { getLocale } from "next-intl/server";
+import { ThemeProvider } from "@/components/theme-provider";
 import "@/app/globals.css";
 
 export const metadata: Metadata = {
@@ -35,9 +36,9 @@ export default async function RootLayout({
   const locale = await getLocale();
 
   return (
-    <html lang={locale} className="dark" data-scroll-behavior="smooth" suppressHydrationWarning>
+    <html lang={locale} data-scroll-behavior="smooth" suppressHydrationWarning>
       <body className="min-h-screen bg-background font-sans antialiased">
-        {children}
+        <ThemeProvider>{children}</ThemeProvider>
       </body>
     </html>
   );

--- a/components/settings/settings-content.test.tsx
+++ b/components/settings/settings-content.test.tsx
@@ -9,6 +9,11 @@ vi.mock("sonner", () => ({
   toast: { error: vi.fn(), success: vi.fn() },
 }));
 
+const mockNextThemes = { theme: "dark", setTheme: vi.fn() };
+vi.mock("next-themes", () => ({
+  useTheme: () => mockNextThemes,
+}));
+
 let mockUserId: string | null | undefined = "user-123";
 vi.mock("@/hooks/useUserId", () => ({
   useUserId: () => mockUserId,
@@ -45,7 +50,6 @@ vi.mock("@/lib/supabase/client", () => ({
 vi.mock("@/lib/settings-helpers", () => ({
   getSetting: vi.fn().mockResolvedValue(null),
   setSetting: vi.fn().mockResolvedValue(undefined),
-  applyTheme: vi.fn(),
 }));
 
 vi.mock("@/lib/constants", () => ({
@@ -87,6 +91,8 @@ describe("SettingsContent", () => {
     queryCallIndex = 0;
     mockQueryResults.length = 0;
     mockUserId = "user-123";
+    mockNextThemes.theme = "dark";
+    mockNextThemes.setTheme = vi.fn();
     mockCaptureImage.mockResolvedValue({ error: "no_file" });
   });
 

--- a/components/settings/settings-content.tsx
+++ b/components/settings/settings-content.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from "react";
 import { useTranslations } from "next-intl";
+import { useTheme } from "next-themes";
 import { useLiveQuery } from "dexie-react-hooks";
 import { Input } from "@/components/ui/input";
 import {
@@ -16,7 +17,7 @@ import { db } from "@/lib/db";
 import { METERING_MODES } from "@/lib/constants";
 import { useUserId } from "@/hooks/useUserId";
 import { useUserTier } from "@/hooks/useUserTier";
-import { getSetting, setSetting, applyTheme } from "@/lib/settings-helpers";
+import { getSetting, setSetting } from "@/lib/settings-helpers";
 import { createClient } from "@/lib/supabase/client";
 import { UpgradePrompt } from "@/components/upgrade-prompt";
 import { getLocalAvatar, setLocalAvatar, uploadAvatar } from "@/lib/avatar";
@@ -61,8 +62,8 @@ export function SettingsContent() {
   const tUpgrade = useTranslations("upgrade");
   const userId = useUserId();
   const { tier, isProUser, isAuthenticated } = useUserTier();
+  const { theme, setTheme } = useTheme();
 
-  const [theme, setTheme] = useState("dark");
   const [displayName, setDisplayName] = useState("");
   const [copyright, setCopyright] = useState("");
   const [defaultMetering, setDefaultMetering] = useState("__none__");
@@ -81,8 +82,6 @@ export function SettingsContent() {
   // Load settings
   useEffect(() => {
     async function load() {
-      const t = await getSetting("theme");
-      if (t) setTheme(t);
       const dn = await getSetting("displayName");
       if (dn) setDisplayName(dn);
       const cr = await getSetting("copyright");
@@ -125,12 +124,6 @@ export function SettingsContent() {
 
   function handleThemeChange(value: string) {
     setTheme(value);
-    setSetting("theme", value);
-    applyTheme(
-      value,
-      document.documentElement,
-      window.matchMedia("(prefers-color-scheme: dark)"),
-    );
     toast.success(t("saved"));
   }
 
@@ -266,7 +259,7 @@ export function SettingsContent() {
           </SettingRow>
 
           <SettingRow label={t("theme")}>
-            <Select value={theme} onValueChange={handleThemeChange}>
+            <Select value={theme ?? "dark"} onValueChange={handleThemeChange}>
               <SelectTrigger aria-label={t("theme")}>
                 <SelectValue />
               </SelectTrigger>

--- a/components/stats/stats-content.tsx
+++ b/components/stats/stats-content.tsx
@@ -18,10 +18,10 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { useStats } from "@/hooks/useStats";
 
 const CHART_HEIGHT = 260;
-const BAR_COLOR = "hsl(var(--primary))";
-const LINE_COLOR = "hsl(var(--primary))";
-const GRID_COLOR = "hsl(var(--border))";
-const TEXT_COLOR = "hsl(var(--muted-foreground))";
+const BAR_COLOR = "var(--primary)";
+const LINE_COLOR = "var(--primary)";
+const GRID_COLOR = "var(--border)";
+const TEXT_COLOR = "var(--muted-foreground)";
 
 function ChartSkeleton() {
   return <Skeleton className="h-[260px] w-full rounded-md" />;
@@ -111,9 +111,9 @@ export function StatsContent() {
                 />
                 <Tooltip
                   contentStyle={{
-                    backgroundColor: "hsl(var(--popover))",
+                    backgroundColor: "var(--popover)",
                     borderColor: GRID_COLOR,
-                    color: "hsl(var(--popover-foreground))",
+                    color: "var(--popover-foreground)",
                     borderRadius: 8,
                   }}
                 />
@@ -150,9 +150,9 @@ export function StatsContent() {
                 />
                 <Tooltip
                   contentStyle={{
-                    backgroundColor: "hsl(var(--popover))",
+                    backgroundColor: "var(--popover)",
                     borderColor: GRID_COLOR,
-                    color: "hsl(var(--popover-foreground))",
+                    color: "var(--popover-foreground)",
                     borderRadius: 8,
                   }}
                 />
@@ -200,9 +200,9 @@ export function StatsContent() {
                 />
                 <Tooltip
                   contentStyle={{
-                    backgroundColor: "hsl(var(--popover))",
+                    backgroundColor: "var(--popover)",
                     borderColor: GRID_COLOR,
-                    color: "hsl(var(--popover-foreground))",
+                    color: "var(--popover-foreground)",
                     borderRadius: 8,
                   }}
                 />
@@ -246,9 +246,9 @@ export function StatsContent() {
                 />
                 <Tooltip
                   contentStyle={{
-                    backgroundColor: "hsl(var(--popover))",
+                    backgroundColor: "var(--popover)",
                     borderColor: GRID_COLOR,
-                    color: "hsl(var(--popover-foreground))",
+                    color: "var(--popover-foreground)",
                     borderRadius: 8,
                   }}
                 />

--- a/components/theme-provider.tsx
+++ b/components/theme-provider.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+import type { ComponentProps } from "react";
+
+export function ThemeProvider({
+  children,
+  ...props
+}: ComponentProps<typeof NextThemesProvider>) {
+  return (
+    <NextThemesProvider
+      attribute="class"
+      defaultTheme="dark"
+      enableSystem
+      disableTransitionOnChange
+      {...props}
+    >
+      {children}
+    </NextThemesProvider>
+  );
+}

--- a/e2e/suites/settings.auth.spec.ts
+++ b/e2e/suites/settings.auth.spec.ts
@@ -9,7 +9,7 @@ test.describe("Settings Persistence", () => {
     await page.getByRole("combobox", { name: /Theme/i }).click();
     await page.getByRole("option", { name: /Light/i }).click();
 
-    // Verify <html> element has "light" class (applied immediately via applyTheme)
+    // Verify <html> element has "light" class (set by next-themes ThemeProvider)
     await expect(page.locator("html")).toHaveClass(/light/);
 
     // Verify the select shows "Light" as the current value

--- a/lib/settings-helpers.test.ts
+++ b/lib/settings-helpers.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import "fake-indexeddb/auto";
-import { applyTheme } from "./settings-helpers";
 import { ArgentDb } from "./db";
 
 // We test getSetting/setSetting by directly using a fresh ArgentDb instance
@@ -48,54 +47,3 @@ describe("getSetting / setSetting (via _syncMeta)", () => {
   });
 });
 
-describe("applyTheme", () => {
-  function mockHtml() {
-    const classes = new Set<string>();
-    return {
-      classList: {
-        add(c: string) { classes.add(c); },
-        remove(c: string) { classes.delete(c); },
-        toggle(c: string, force: boolean) { force ? classes.add(c) : classes.delete(c); },
-      },
-      _classes: classes,
-    };
-  }
-
-  it("dark theme adds dark, removes light", () => {
-    const html = mockHtml();
-    html._classes.add("light");
-    applyTheme("dark", html, { matches: false });
-    expect(html._classes.has("dark")).toBe(true);
-    expect(html._classes.has("light")).toBe(false);
-  });
-
-  it("light theme removes dark, adds light", () => {
-    const html = mockHtml();
-    html._classes.add("dark");
-    applyTheme("light", html, { matches: false });
-    expect(html._classes.has("dark")).toBe(false);
-    expect(html._classes.has("light")).toBe(true);
-  });
-
-  it("system theme with prefers-dark adds dark", () => {
-    const html = mockHtml();
-    applyTheme("system", html, { matches: true });
-    expect(html._classes.has("dark")).toBe(true);
-    expect(html._classes.has("light")).toBe(false);
-  });
-
-  it("system theme with prefers-light adds light", () => {
-    const html = mockHtml();
-    applyTheme("system", html, { matches: false });
-    expect(html._classes.has("dark")).toBe(false);
-    expect(html._classes.has("light")).toBe(true);
-  });
-
-  it("system with prefers-dark removes existing light class", () => {
-    const html = mockHtml();
-    html._classes.add("light");
-    applyTheme("system", html, { matches: true });
-    expect(html._classes.has("dark")).toBe(true);
-    expect(html._classes.has("light")).toBe(false);
-  });
-});

--- a/lib/settings-helpers.ts
+++ b/lib/settings-helpers.ts
@@ -16,26 +16,3 @@ export async function getSetting(key: string): Promise<string | null> {
 export async function setSetting(key: string, value: string): Promise<void> {
   await db._syncMeta.put({ key, value });
 }
-
-/**
- * Apply theme to the HTML element.
- * Accepts a theme string ("dark", "light", or "system") and manipulates classes.
- */
-export function applyTheme(
-  theme: string,
-  htmlElement: { classList: { add(c: string): void; remove(c: string): void; toggle(c: string, force: boolean): void } },
-  matchMedia: { matches: boolean },
-): void {
-  if (theme === "dark") {
-    htmlElement.classList.add("dark");
-    htmlElement.classList.remove("light");
-  } else if (theme === "light") {
-    htmlElement.classList.remove("dark");
-    htmlElement.classList.add("light");
-  } else {
-    // System
-    const prefersDark = matchMedia.matches;
-    htmlElement.classList.toggle("dark", prefersDark);
-    htmlElement.classList.toggle("light", !prefersDark);
-  }
-}


### PR DESCRIPTION
## Summary

- **Wire up `next-themes` ThemeProvider** at the root layout — theme preference now persists across navigation and page reloads via `localStorage`
- **Fix chart colors** on the Statistics page — replace `hsl(var(--...))` with `var(--...)` to match Tailwind v4's `oklch()` CSS variables
- **Remove dead code** — delete `applyTheme` function and its tests, replace custom IndexedDB theme storage with `useTheme()` from next-themes

Closes #64 (consolidation of #56 and #57)

## What changed

| File | Change |
|------|--------|
| `components/theme-provider.tsx` | **New** — `'use client'` wrapper for next-themes ThemeProvider |
| `app/layout.tsx` | Removed hardcoded `className="dark"`, added `ThemeProvider` |
| `lib/settings-helpers.ts` | Deleted `applyTheme` (dead code) |
| `components/settings/settings-content.tsx` | Replaced custom theme state with `useTheme()` |
| `components/stats/stats-content.tsx` | Replaced 12 `hsl(var(--...))` with `var(--...)` |
| `lib/settings-helpers.test.ts` | Removed `applyTheme` test suite |
| `components/settings/settings-content.test.tsx` | Added `next-themes` mock, removed `applyTheme` mock |
| `e2e/suites/settings.auth.spec.ts` | Updated stale comment |

## Root causes fixed

**Theme persistence (#56):** `app/layout.tsx` hardcoded `className="dark"` on `<html>` for every SSR render. Theme was stored in async IndexedDB — inaccessible during SSR. `next-themes` was installed but never wired up. Now `ThemeProvider` manages the `<html>` class attribute with `localStorage` persistence.

**Chart visibility (#57):** CSS variables migrated to `oklch()` values in Tailwind v4, but chart color strings still used the Tailwind v3 pattern `hsl(var(--primary))`. The browser resolved this as `hsl(oklch(...))` — invalid CSS — causing SVG to fall back to black fills.

## Test plan

- [x] 864/864 unit tests pass
- [x] TypeScript strict mode: clean
- [x] ESLint: clean
- [x] Production build: passes
- [ ] Manual: toggle theme in Settings, navigate to other pages, verify persistence
- [ ] Manual: visit `/stats` with data, verify charts are visible in both themes
- [ ] E2E: settings persistence suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)