### PR TITLE
fix: translate hardcoded "Soon" badge on marketing page

### DIFF
--- a/app/[locale]/(marketing)/page.tsx
+++ b/app/[locale]/(marketing)/page.tsx
@@ -249,7 +249,7 @@ function LandingPage({ locale }: { locale: string }) {
                 <div className="flex items-center gap-3">
                   <h3 className="text-2xl font-bold">{t("pricing.pro")}</h3>
                   <span className="rounded-full bg-amber-500/10 px-2.5 py-0.5 text-xs font-medium text-amber-500">
-                    Soon
+                    {t("pricing.soonBadge")}
                   </span>
                 </div>
                 <p className="mt-2 text-3xl font-bold">

--- a/messages/en.json
+++ b/messages/en.json
@@ -73,6 +73,7 @@
       "free": "Free",
       "pro": "Pro",
       "comingSoon": "Coming Soon",
+      "soonBadge": "Soon",
       "joinWaitlist": "Join Waitlist",
       "getStarted": "Get Started",
       "freeFeatures": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -73,6 +73,7 @@
       "free": "Gratis",
       "pro": "Pro",
       "comingSoon": "Próximamente",
+      "soonBadge": "Pronto",
       "joinWaitlist": "Unirse a la Lista de Espera",
       "getStarted": "Comenzar",
       "freeFeatures": {


### PR DESCRIPTION
## Summary

- Replace hardcoded English `"Soon"` text on the Pro pricing badge with `t("pricing.soonBadge")` 
- Add `soonBadge` translation key to both `en.json` ("Soon") and `es.json` ("Pronto")

Closes #58

## Changes

| File | Change |
|------|--------|
| `app/[locale]/(marketing)/page.tsx` | Replace hardcoded `Soon` with `{t("pricing.soonBadge")}` |
| `messages/en.json` | Add `"soonBadge": "Soon"` to `marketing.pricing` |
| `messages/es.json` | Add `"soonBadge": "Pronto"` to `marketing.pricing` |

## Test plan

- [x] TypeScript: clean
- [x] Production build: passes
- [ ] Manual: visit `/` — Pro badge shows "Soon"
- [ ] Manual: visit `/es` — Pro badge shows "Pronto"

🤖 Generated with [Claude Code](https://claude.com/claude-code)