### PR TITLE
feat: add Settings shortcut to user profile dropdown

### DIFF
--- a/components/user-menu.test.tsx
+++ b/components/user-menu.test.tsx
@@ -22,7 +22,12 @@ vi.mock("@/app/(app)/settings/actions", () => ({
   joinWaitlist: vi.fn().mockResolvedValue({ success: true }),
 }));
 
+vi.mock("@/lib/avatar", () => ({
+  clearGlobalAvatarKey: vi.fn(),
+}));
+
 import { UserMenu } from "./user-menu";
+import userEvent from "@testing-library/user-event";
 
 describe("UserMenu", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -74,5 +79,17 @@ describe("UserMenu", () => {
       />,
     );
     expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("renders settings link in dropdown menu", async () => {
+    const user = userEvent.setup();
+    render(
+      <UserMenu userId="user-1" email="test@example.com" tier="free" />,
+    );
+    await user.click(screen.getByRole("button", { name: "test@example.com" }));
+    const settingsItem = screen.getByText("settings");
+    expect(settingsItem).toBeDefined();
+    expect(settingsItem.closest("a")).toBeDefined();
+    expect(settingsItem.closest("a")!.getAttribute("href")).toBe("/settings");
   });
 });

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -2,7 +2,7 @@
 
 import { useTransition } from "react";
 import { useTranslations } from "next-intl";
-import { Camera, Aperture, Film, LogOut, Sparkles } from "lucide-react";
+import { Camera, Aperture, Film, LogOut, Settings, Sparkles } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
   DropdownMenu,
@@ -15,6 +15,7 @@ import {
 import { getUserAvatar, type AvatarIcon } from "@/lib/user-avatar";
 import { signOut, joinWaitlist } from "@/app/(app)/settings/actions";
 import { clearGlobalAvatarKey } from "@/lib/avatar";
+import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
 
@@ -87,6 +88,12 @@ export function UserMenu({ userId, email, tier, displayName, avatarUrl }: UserMe
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
+        <DropdownMenuItem asChild>
+          <Link href="/settings">
+            <Settings className="h-4 w-4" />
+            {tNav("settings")}
+          </Link>
+        </DropdownMenuItem>
         {tier === "free" && (
           <DropdownMenuItem disabled={pending} onSelect={handleJoinWaitlist}>
             <Sparkles className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- Adds a "Settings" link with gear icon to the user profile dropdown, positioned above "Sign Out"
- Uses existing `nav.settings` i18n key (no new translations needed)
- Uses `DropdownMenuItem asChild` with `next/link` for client-side navigation

Closes #63

## Test plan
- [x] New test: verifies Settings link renders in dropdown with correct href
- [x] All 890 unit tests pass
- [x] TypeScript strict: clean
- [x] ESLint: clean
- [ ] Manual: open dropdown on desktop sidebar and mobile header, verify Settings link navigates to `/settings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)