### PR TITLE
feat: add sitemap, robots.txt, and Twitter card metadata

### DIFF
--- a/app/[locale]/(marketing)/page.tsx
+++ b/app/[locale]/(marketing)/page.tsx
@@ -31,6 +31,11 @@ export async function generateMetadata({
       type: "website",
       siteName: "Argent",
     },
+    twitter: {
+      card: "summary_large_image",
+      title: `Argent — ${t("hero.title")}`,
+      description: t("hero.subtitle"),
+    },
   };
 }
 

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL =
+  process.env.NEXT_PUBLIC_APP_URL ?? "https://argent.photo";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: ["/", "/es"],
+        disallow: [
+          "/gear",
+          "/roll/",
+          "/settings",
+          "/stats",
+          "/login",
+          "/reset-password",
+          "/auth/",
+          "/api/",
+        ],
+      },
+    ],
+    sitemap: `${BASE_URL}/sitemap.xml`,
+  };
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,26 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL =
+  process.env.NEXT_PUBLIC_APP_URL ?? "https://argent.photo";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+      alternates: {
+        languages: {
+          es: `${BASE_URL}/es`,
+        },
+      },
+    },
+    {
+      url: `${BASE_URL}/es`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

- Added `app/sitemap.ts` — includes marketing pages (`/`, `/es`) with hreflang alternates and monthly change frequency
- Added `app/robots.ts` — allows crawling of marketing pages, disallows app routes (`/gear`, `/roll/`, `/settings`, `/stats`, `/login`, `/reset-password`, `/auth/`, `/api/`)
- Added Twitter card metadata (`summary_large_image`) to marketing page `generateMetadata`

## Test plan

- [ ] Verify `/sitemap.xml` returns valid XML with both locale URLs
- [ ] Verify `/robots.txt` returns correct allow/disallow rules and sitemap reference
- [ ] Check Twitter Card Validator renders card correctly for marketing page URL
- [ ] Confirm OG tags still work (no regression)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)