### PR TITLE
feat: add global error boundary and 404 page

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useEffect } from "react";
+import Link from "next/link";
+import { Logo } from "@/components/logo";
+import { Button } from "@/components/ui/button";
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string };
+  reset: () => void;
+}) {
+  useEffect(() => {
+    console.error(error);
+  }, [error]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center px-4 text-center">
+      <Logo className="mb-8 h-10 text-muted-foreground" />
+      <h1 className="text-2xl font-bold tracking-tight">
+        Something went wrong
+      </h1>
+      <p className="mt-3 max-w-sm text-sm text-muted-foreground">
+        An unexpected error occurred. You can try again or go back to the app.
+      </p>
+      <div className="mt-8 flex gap-3">
+        <Button onClick={reset} variant="default">
+          Try again
+        </Button>
+        <Button variant="outline" asChild>
+          <Link href="/gear">Go home</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { Logo } from "@/components/logo";
+import { Button } from "@/components/ui/button";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center px-4 text-center">
+      <Logo className="mb-8 h-10 text-muted-foreground" />
+      <h1 className="text-2xl font-bold tracking-tight">Page not found</h1>
+      <p className="mt-3 max-w-sm text-sm text-muted-foreground">
+        The page you&apos;re looking for doesn&apos;t exist or has been moved.
+      </p>
+      <Button className="mt-8" asChild>
+        <Link href="/gear">Go home</Link>
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Added `app/error.tsx` — client component with "Try again" (calls `reset()`) and "Go home" link to `/gear`
- Added `app/not-found.tsx` — server component with friendly 404 message and navigation home

Both pages use the existing `Logo` and `Button` components and match the app's dark theme design. Strings are hardcoded rather than using `next-intl` since these pages render at the root layout level, outside `NextIntlClientProvider` — keeping them dependency-light avoids infinite error loops if i18n itself fails.

## Test plan

- [ ] Navigate to a non-existent URL (e.g., `/nonexistent`) and verify the 404 page renders
- [ ] Trigger an error in a component and verify the error boundary renders with retry
- [ ] Verify "Go home" links navigate to `/gear`
- [ ] Verify "Try again" button calls `reset()` and re-renders

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)