### PR TITLE
fix: point pricing CTA to signup instead of login

### DIFF
--- a/app/[locale]/(marketing)/page.tsx
+++ b/app/[locale]/(marketing)/page.tsx
@@ -244,7 +244,7 @@ function LandingPage({ locale }: { locale: string }) {
                 ))}
               </ul>
               <Link
-                href="/login"
+                href="/login?mode=signup"
                 className="mt-auto block rounded-xl bg-primary px-6 py-3 text-center text-sm font-semibold text-primary-foreground transition-all duration-200 hover:bg-primary/90 hover:shadow-md hover:-translate-y-0.5 active:translate-y-0 active:scale-[0.97]"
               >
                 {t("pricing.getStarted")}


### PR DESCRIPTION
## Summary

- Changed the Free tier "Get Started" link from `/login` to `/login?mode=signup` so new users land on the signup form, matching the hero CTA behavior

## Test plan

- [ ] Click "Get Started" on the Free pricing card — should open signup form, not login

🤖 Generated with [Claude Code](https://claude.com/claude-code)