### PR TITLE
feat: add in-app feedback form → GitHub Issues

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,10 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
 RESEND_API_KEY=re_your_key_here
 EMAIL_FROM=Argent <noreply@argent.photo>
 
+# GitHub Feedback — Fine-grained PAT with issues:write on the feedback repo
+GITHUB_FEEDBACK_TOKEN=ghp_your_token_here
+GITHUB_FEEDBACK_REPO=Zenemig/argent
+
 # E2E test credentials — a confirmed Supabase user for Playwright authenticated tests
 # E2E_USER_EMAIL=test@example.com
 # E2E_USER_PASSWORD=testpassword123

--- a/app/api/feedback/route.test.ts
+++ b/app/api/feedback/route.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared BEFORE the import under test
+// ---------------------------------------------------------------------------
+
+const mockGetUser = vi.fn();
+vi.mock("@/lib/supabase/server", () => ({
+  createClient: () => ({
+    auth: { getUser: mockGetUser },
+    from: () => ({
+      select: () => ({
+        eq: () => ({
+          single: () => Promise.resolve({ data: { tier: "free" }, error: null }),
+        }),
+      }),
+    }),
+  }),
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { POST, _resetRateLimits } from "./route";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost:3000/api/feedback", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  category: "bug",
+  description: "Something is broken when I try to log a shot",
+  includeEmail: true,
+  metadata: { page: "/roll/abc123", userAgent: "Mozilla/5.0" },
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("POST /api/feedback", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: "user-1", email: "test@test.com" } },
+    });
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ id: 1, html_url: "https://github.com/..." }), {
+        status: 201,
+      }),
+    );
+    _resetRateLimits();
+  });
+
+  it("returns 401 when user is not authenticated", async () => {
+    mockGetUser.mockResolvedValue({ data: { user: null } });
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for invalid payload (description too short)", async () => {
+    const res = await POST(
+      makeRequest({ ...validBody, description: "short" }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 400 for missing category", async () => {
+    const { category: _, ...noCategory } = validBody;
+    const res = await POST(makeRequest(noCategory));
+    expect(res.status).toBe(400);
+  });
+
+  it("creates a GitHub issue with correct title and labels for bug", async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain("/repos/");
+    expect(url).toContain("/issues");
+
+    const body = JSON.parse(options.body);
+    expect(body.title).toContain("[Bug]");
+    expect(body.labels).toContain("feedback");
+    expect(body.labels).toContain("bug");
+  });
+
+  it("creates a GitHub issue with correct title for feature request", async () => {
+    const res = await POST(
+      makeRequest({ ...validBody, category: "feature" }),
+    );
+    expect(res.status).toBe(200);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.title).toContain("[Feature]");
+    expect(body.labels).toContain("enhancement");
+  });
+
+  it("creates a GitHub issue with correct title for general feedback", async () => {
+    const res = await POST(
+      makeRequest({ ...validBody, category: "general" }),
+    );
+    expect(res.status).toBe(200);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.title).toContain("[Feedback]");
+    expect(body.labels).toContain("feedback");
+  });
+
+  it("includes email in body when includeEmail is true", async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.body).toContain("test@test.com");
+  });
+
+  it("omits email when includeEmail is false", async () => {
+    const res = await POST(
+      makeRequest({ ...validBody, includeEmail: false }),
+    );
+    expect(res.status).toBe(200);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.body).not.toContain("test@test.com");
+  });
+
+  it("includes metadata in issue body", async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body.body).toContain("/roll/abc123");
+    expect(body.body).toContain("Mozilla/5.0");
+  });
+
+  it("returns 500 when GitHub API fails", async () => {
+    mockFetch.mockResolvedValue(new Response("", { status: 422 }));
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(500);
+  });
+
+  it("returns 429 when submitting again within rate limit window", async () => {
+    await POST(makeRequest(validBody));
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(429);
+  });
+
+  it("truncates long descriptions in the issue title", async () => {
+    const longDesc = "A".repeat(100);
+    const res = await POST(
+      makeRequest({ ...validBody, description: longDesc }),
+    );
+    expect(res.status).toBe(200);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    // Title should be capped (prefix + 60 chars max)
+    expect(body.title.length).toBeLessThanOrEqual(70);
+  });
+});

--- a/app/api/feedback/route.ts
+++ b/app/api/feedback/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { feedbackPayloadSchema } from "@/lib/schemas";
+
+// ---------------------------------------------------------------------------
+// In-memory rate limit (userId → last submission timestamp)
+// Acceptable for serverless — worst case a cold start resets the map.
+// ---------------------------------------------------------------------------
+const rateLimitMap = new Map<string, number>();
+const RATE_LIMIT_MS = 5 * 60 * 1000; // 5 minutes
+
+/** @internal — for test cleanup only */
+export function _resetRateLimits() {
+  rateLimitMap.clear();
+}
+
+const CATEGORY_LABELS: Record<string, { prefix: string; label: string }> = {
+  bug: { prefix: "[Bug]", label: "bug" },
+  feature: { prefix: "[Feature]", label: "enhancement" },
+  general: { prefix: "[Feedback]", label: "feedback" },
+};
+
+export async function POST(request: Request) {
+  // 1. Authenticate
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+
+  // 2. Parse & validate
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalidJson" }, { status: 400 });
+  }
+
+  const parsed = feedbackPayloadSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "validation", details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  const { category, description, includeEmail, metadata } = parsed.data;
+
+  // 3. Rate limit
+  const lastSubmission = rateLimitMap.get(user.id);
+  if (lastSubmission && Date.now() - lastSubmission < RATE_LIMIT_MS) {
+    return NextResponse.json({ error: "rateLimited" }, { status: 429 });
+  }
+
+  // 4. Fetch user tier
+  const { data: profile } = await supabase
+    .from("user_profiles")
+    .select("tier")
+    .eq("id", user.id)
+    .single();
+
+  const tier = profile?.tier ?? "free";
+
+  // 5. Build issue
+  const { prefix, label } = CATEGORY_LABELS[category] ?? CATEGORY_LABELS.general;
+  const truncatedDesc = description.length > 60 ? description.slice(0, 57) + "..." : description;
+  const title = `${prefix} ${truncatedDesc}`;
+
+  const emailLine = includeEmail && user.email
+    ? `- **Email:** ${user.email}`
+    : "";
+
+  const issueBody = `${description}
+
+---
+
+<details>
+<summary>Metadata</summary>
+
+- **Tier:** ${tier}
+- **Browser:** ${metadata.userAgent}
+- **Page:** ${metadata.page}
+${emailLine}
+
+</details>`;
+
+  const labels = ["feedback"];
+  if (label !== "feedback") labels.push(label);
+
+  // 6. Create GitHub issue
+  const repo = process.env.GITHUB_FEEDBACK_REPO;
+  const token = process.env.GITHUB_FEEDBACK_TOKEN;
+
+  const ghResponse = await fetch(
+    `https://api.github.com/repos/${repo}/issues`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ title, body: issueBody, labels }),
+    },
+  );
+
+  if (!ghResponse.ok) {
+    console.error("[feedback] GitHub API error:", ghResponse.status);
+    return NextResponse.json({ error: "githubError" }, { status: 500 });
+  }
+
+  // 7. Record rate limit
+  rateLimitMap.set(user.id, Date.now());
+
+  return NextResponse.json({ success: true });
+}

--- a/components/feedback/feedback-dialog.test.tsx
+++ b/components/feedback/feedback-dialog.test.tsx
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+// Mock shadcn Dialog to render children directly in jsdom
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div data-testid="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogHeader: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  DialogTitle: ({ children }: { children: React.ReactNode }) => (
+    <h2>{children}</h2>
+  ),
+  DialogDescription: ({ children }: { children: React.ReactNode }) => (
+    <p>{children}</p>
+  ),
+}));
+
+// Mock Radix Select — renders as native select for testing
+vi.mock("@/components/ui/select", () => ({
+  Select: ({
+    children,
+    onValueChange,
+  }: {
+    children: React.ReactNode;
+    onValueChange?: (v: string) => void;
+  }) => (
+    <div
+      data-testid="select-root"
+      onChange={(e: React.ChangeEvent<HTMLElement>) => {
+        const target = e.target as HTMLSelectElement;
+        onValueChange?.(target.value);
+      }}
+    >
+      {children}
+    </div>
+  ),
+  SelectTrigger: ({ children, ...props }: { children: React.ReactNode; "aria-label"?: string }) => (
+    <button type="button" {...props}>{children}</button>
+  ),
+  SelectValue: ({ placeholder }: { placeholder?: string }) => (
+    <span>{placeholder}</span>
+  ),
+  SelectContent: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
+  SelectItem: ({
+    children,
+    value,
+  }: {
+    children: React.ReactNode;
+    value: string;
+  }) => <option value={value}>{children}</option>,
+}));
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { FeedbackDialog } from "./feedback-dialog";
+import { toast } from "sonner";
+
+describe("FeedbackDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ success: true }), { status: 200 }),
+    );
+  });
+
+  it("renders nothing when closed", () => {
+    render(<FeedbackDialog open={false} onOpenChange={vi.fn()} />);
+    expect(screen.queryByTestId("dialog")).toBeNull();
+  });
+
+  it("renders dialog title when open", () => {
+    render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+    expect(screen.getByText("title")).toBeDefined();
+  });
+
+  it("renders category select", () => {
+    render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+    expect(screen.getByText("categoryPlaceholder")).toBeDefined();
+  });
+
+  it("renders description textarea", () => {
+    render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+    const textarea = screen.getByPlaceholderText("messagePlaceholder");
+    expect(textarea).toBeDefined();
+  });
+
+  it("renders email opt-in checkbox", () => {
+    render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+    expect(screen.getByText("includeEmail")).toBeDefined();
+  });
+
+  it("renders submit button", () => {
+    render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+    expect(screen.getByText("submit")).toBeDefined();
+  });
+
+  it("submits feedback and shows success toast", async () => {
+    const onOpenChange = vi.fn();
+    render(<FeedbackDialog open={true} onOpenChange={onOpenChange} />);
+
+    // Fill textarea
+    const textarea = screen.getByPlaceholderText("messagePlaceholder");
+    fireEvent.change(textarea, {
+      target: { value: "This is a detailed bug report for testing" },
+    });
+
+    // Submit
+    const submitBtn = screen.getByText("submit");
+    fireEvent.click(submitBtn);
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/feedback",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("success");
+    });
+  });
+
+  it("shows error toast on API failure", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: "githubError" }), { status: 500 }),
+    );
+
+    render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+
+    const textarea = screen.getByPlaceholderText("messagePlaceholder");
+    fireEvent.change(textarea, {
+      target: { value: "This is a detailed bug report for testing" },
+    });
+
+    fireEvent.click(screen.getByText("submit"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("error");
+    });
+  });
+
+  it("shows rate limited toast on 429", async () => {
+    mockFetch.mockResolvedValue(
+      new Response(JSON.stringify({ error: "rateLimited" }), { status: 429 }),
+    );
+
+    render(<FeedbackDialog open={true} onOpenChange={vi.fn()} />);
+
+    const textarea = screen.getByPlaceholderText("messagePlaceholder");
+    fireEvent.change(textarea, {
+      target: { value: "This is a detailed bug report for testing" },
+    });
+
+    fireEvent.click(screen.getByText("submit"));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("rateLimited");
+    });
+  });
+});

--- a/components/feedback/feedback-dialog.tsx
+++ b/components/feedback/feedback-dialog.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { FEEDBACK_CATEGORIES } from "@/lib/constants";
+import type { FeedbackCategory } from "@/lib/constants";
+
+interface FeedbackDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const CATEGORY_KEYS: Record<FeedbackCategory, string> = {
+  bug: "categoryBug",
+  feature: "categoryFeature",
+  general: "categoryGeneral",
+};
+
+export function FeedbackDialog({ open, onOpenChange }: FeedbackDialogProps) {
+  const t = useTranslations("feedback");
+  const [category, setCategory] = useState<FeedbackCategory | "">("");
+  const [description, setDescription] = useState("");
+  const [includeEmail, setIncludeEmail] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleSubmit() {
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          category: category || "general",
+          description,
+          includeEmail,
+          metadata: {
+            page: window.location.pathname,
+            userAgent: navigator.userAgent,
+          },
+        }),
+      });
+
+      if (res.status === 429) {
+        toast.error(t("rateLimited"));
+        return;
+      }
+
+      if (!res.ok) {
+        toast.error(t("error"));
+        return;
+      }
+
+      toast.success(t("success"));
+      // Reset form
+      setCategory("");
+      setDescription("");
+      setIncludeEmail(false);
+      onOpenChange(false);
+    } catch {
+      toast.error(t("error"));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("title")}</DialogTitle>
+          <DialogDescription>{t("description")}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label>{t("category")}</Label>
+            <Select
+              value={category}
+              onValueChange={(v) => setCategory(v as FeedbackCategory)}
+            >
+              <SelectTrigger aria-label={t("category")}>
+                <SelectValue placeholder={t("categoryPlaceholder")} />
+              </SelectTrigger>
+              <SelectContent>
+                {FEEDBACK_CATEGORIES.map((cat) => (
+                  <SelectItem key={cat} value={cat}>
+                    {t(CATEGORY_KEYS[cat])}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          <div className="space-y-2">
+            <Label>{t("message")}</Label>
+            <Textarea
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={t("messagePlaceholder")}
+              rows={4}
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="include-email"
+              checked={includeEmail}
+              onCheckedChange={(checked) =>
+                setIncludeEmail(checked === true)
+              }
+            />
+            <Label htmlFor="include-email" className="text-sm font-normal">
+              {t("includeEmail")}
+            </Label>
+          </div>
+
+          <Button
+            onClick={handleSubmit}
+            disabled={submitting}
+            className="w-full"
+          >
+            {submitting ? t("sending") : t("submit")}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/settings/settings-content.test.tsx
+++ b/components/settings/settings-content.test.tsx
@@ -64,6 +64,10 @@ vi.mock("./delete-account-section", () => ({
   DeleteAccountSection: () => <div data-testid="delete-account-section" />,
 }));
 
+vi.mock("@/components/feedback/feedback-dialog", () => ({
+  FeedbackDialog: () => null,
+}));
+
 const mockCaptureImage = vi.fn();
 vi.mock("@/lib/image-capture", () => ({
   captureImage: (...args: unknown[]) => mockCaptureImage(...args),
@@ -148,9 +152,10 @@ describe("SettingsContent", () => {
     mockQueryResults.push(undefined);
     render(<SettingsContent />);
     const headings = screen.getAllByRole("heading", { level: 2 });
-    expect(headings).toHaveLength(2);
+    expect(headings).toHaveLength(3);
     expect(headings[0].textContent).toBe("preferences");
     expect(headings[1].textContent).toBe("metadata");
+    expect(headings[2].textContent).toBe("feedback");
   });
 
   it("renders avatar button with changeAvatar label", async () => {

--- a/components/settings/settings-content.tsx
+++ b/components/settings/settings-content.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { MessageSquarePlus } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { FeedbackDialog } from "@/components/feedback/feedback-dialog";
 import { useTranslations } from "next-intl";
 import { useTheme } from "next-themes";
 import { useLiveQuery } from "dexie-react-hooks";
@@ -70,6 +73,7 @@ export function SettingsContent() {
   const [userEmail, setUserEmail] = useState<string | null>(null);
   const [avatarUrl, setAvatarUrl] = useState<string | null>(null);
   const [isUploadingAvatar, setIsUploadingAvatar] = useState(false);
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
 
   // Check auth state on mount
   useEffect(() => {
@@ -350,6 +354,23 @@ export function SettingsContent() {
           <DeleteAccountSection />
         </div>
       )}
+
+      {/* Feedback section */}
+      <div>
+        <SectionHeader>{t("feedback")}</SectionHeader>
+        <div className="mt-3">
+          <p className="text-sm text-muted-foreground">{t("feedbackDescription")}</p>
+          <Button
+            variant="outline"
+            className="mt-3"
+            onClick={() => setFeedbackOpen(true)}
+          >
+            <MessageSquarePlus className="h-4 w-4" />
+            {t("feedback")}
+          </Button>
+        </div>
+      </div>
+      <FeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
 
       <p className="text-sm text-muted-foreground">
         {t("about")} · {t("version")} 0.1.0

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useTransition } from "react";
+import { useState, useTransition } from "react";
 import { useTranslations } from "next-intl";
-import { Camera, Aperture, Film, LogOut, Settings, Sparkles } from "lucide-react";
+import { Camera, Aperture, Film, LogOut, Settings, Sparkles, MessageSquarePlus } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
   DropdownMenu,
@@ -18,6 +18,7 @@ import { clearGlobalAvatarKey } from "@/lib/avatar";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { toast } from "sonner";
+import { FeedbackDialog } from "@/components/feedback/feedback-dialog";
 
 const ICON_MAP = {
   camera: Camera,
@@ -38,6 +39,7 @@ export function UserMenu({ userId, email, tier, displayName, avatarUrl }: UserMe
   const tNav = useTranslations("nav");
   const tUpgrade = useTranslations("upgrade");
   const [pending, startTransition] = useTransition();
+  const [feedbackOpen, setFeedbackOpen] = useState(false);
   const avatar = getUserAvatar(userId);
   const Icon = ICON_MAP[avatar.icon];
 
@@ -51,6 +53,7 @@ export function UserMenu({ userId, email, tier, displayName, avatarUrl }: UserMe
   }
 
   return (
+    <>
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <button
@@ -94,6 +97,10 @@ export function UserMenu({ userId, email, tier, displayName, avatarUrl }: UserMe
             {tNav("settings")}
           </Link>
         </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => setFeedbackOpen(true)}>
+          <MessageSquarePlus className="h-4 w-4" />
+          {tNav("sendFeedback")}
+        </DropdownMenuItem>
         {tier === "free" && (
           <DropdownMenuItem disabled={pending} onSelect={handleJoinWaitlist}>
             <Sparkles className="h-4 w-4" />
@@ -112,5 +119,7 @@ export function UserMenu({ userId, email, tier, displayName, avatarUrl }: UserMe
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>
+    <FeedbackDialog open={feedbackOpen} onOpenChange={setFeedbackOpen} />
+    </>
   );
 }

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -131,6 +131,10 @@ export function formatLabel(value: string): string {
   return value.charAt(0).toUpperCase() + value.slice(1);
 }
 
+/** Feedback categories */
+export const FEEDBACK_CATEGORIES = ["bug", "feature", "general"] as const;
+export type FeedbackCategory = (typeof FEEDBACK_CATEGORIES)[number];
+
 /** Sync queue operation types */
 export const SYNC_OPERATIONS = ["create", "update", "delete"] as const;
 export type SyncOperation = (typeof SYNC_OPERATIONS)[number];

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -11,6 +11,7 @@ import {
   USER_TIERS,
   LENS_MOUNTS,
   CAMERA_TYPES,
+  FEEDBACK_CATEGORIES,
 } from "./constants";
 
 // ---------------------------------------------------------------------------
@@ -229,3 +230,19 @@ export const userProfileSchema = z.object({
 });
 
 export type UserProfile = z.infer<typeof userProfileSchema>;
+
+// ---------------------------------------------------------------------------
+// Feedback Payload (client → API route)
+// ---------------------------------------------------------------------------
+
+export const feedbackPayloadSchema = z.object({
+  category: z.enum(FEEDBACK_CATEGORIES),
+  description: z.string().min(10).max(5000),
+  includeEmail: z.boolean(),
+  metadata: z.object({
+    page: z.string(),
+    userAgent: z.string(),
+  }),
+});
+
+export type FeedbackPayload = z.infer<typeof feedbackPayloadSchema>;

--- a/messages/en.json
+++ b/messages/en.json
@@ -22,7 +22,8 @@
     "gear": "Gear Bag",
     "settings": "Settings",
     "stats": "Statistics",
-    "signOut": "Sign Out"
+    "signOut": "Sign Out",
+    "sendFeedback": "Send Feedback"
   },
   "marketing": {
     "hero": {
@@ -321,6 +322,8 @@
     "avatarError": "Failed to update avatar",
     "preferences": "Preferences",
     "metadata": "Metadata",
+    "feedback": "Feedback",
+    "feedbackDescription": "Help us improve Argent",
     "dangerZone": "Danger Zone",
     "deleteAccount": "Delete Account",
     "deleteAccountDescription": "Permanently delete your account and all data. This cannot be undone.",
@@ -413,5 +416,22 @@
     "updatePasswordFailed": "Could not update password. Please try again.",
     "showPassword": "Show password",
     "hidePassword": "Hide password"
+  },
+  "feedback": {
+    "title": "Send Feedback",
+    "description": "Help us improve Argent. Bug reports, feature requests, and general feedback are all welcome.",
+    "category": "Category",
+    "categoryBug": "Bug report",
+    "categoryFeature": "Feature request",
+    "categoryGeneral": "General feedback",
+    "categoryPlaceholder": "Select a category",
+    "message": "Description",
+    "messagePlaceholder": "Tell us what happened, what you expected, or what you'd like to see...",
+    "includeEmail": "Include my email for follow-up",
+    "submit": "Send Feedback",
+    "sending": "Sending...",
+    "success": "Thank you for your feedback!",
+    "error": "Failed to send feedback. Please try again.",
+    "rateLimited": "Please wait a few minutes before submitting again."
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -22,7 +22,8 @@
     "gear": "Equipo",
     "settings": "Ajustes",
     "stats": "Estadísticas",
-    "signOut": "Cerrar Sesión"
+    "signOut": "Cerrar Sesión",
+    "sendFeedback": "Enviar Comentarios"
   },
   "marketing": {
     "hero": {
@@ -321,6 +322,8 @@
     "avatarError": "Error al actualizar el avatar",
     "preferences": "Preferencias",
     "metadata": "Metadatos",
+    "feedback": "Comentarios",
+    "feedbackDescription": "Ayúdanos a mejorar Argent",
     "dangerZone": "Zona de Peligro",
     "deleteAccount": "Eliminar Cuenta",
     "deleteAccountDescription": "Elimina permanentemente tu cuenta y todos los datos. Esto no se puede deshacer.",
@@ -413,5 +416,22 @@
     "updatePasswordFailed": "No se pudo actualizar la contraseña. Intenta de nuevo.",
     "showPassword": "Mostrar contraseña",
     "hidePassword": "Ocultar contraseña"
+  },
+  "feedback": {
+    "title": "Enviar Comentarios",
+    "description": "Ayúdanos a mejorar Argent. Reportes de errores, solicitudes de funciones y comentarios generales son bienvenidos.",
+    "category": "Categoría",
+    "categoryBug": "Reporte de error",
+    "categoryFeature": "Solicitud de función",
+    "categoryGeneral": "Comentario general",
+    "categoryPlaceholder": "Selecciona una categoría",
+    "message": "Descripción",
+    "messagePlaceholder": "Cuéntanos qué pasó, qué esperabas o qué te gustaría ver...",
+    "includeEmail": "Incluir mi correo para seguimiento",
+    "submit": "Enviar Comentarios",
+    "sending": "Enviando...",
+    "success": "¡Gracias por tus comentarios!",
+    "error": "Error al enviar comentarios. Inténtalo de nuevo.",
+    "rateLimited": "Espera unos minutos antes de enviar de nuevo."
   }
 }


### PR DESCRIPTION
## Summary
- Adds a feedback dialog (bug report / feature request / general) accessible from the user dropdown menu and settings page
- Submissions create labeled GitHub issues via an API route with Zod validation, auth, and 5-minute rate limiting
- Includes i18n support (en + es), collapsible metadata in issue body (tier, browser, page, optional email)

## New Files
- `app/api/feedback/route.ts` — API route (auth, validation, rate limit, GitHub issue creation)
- `app/api/feedback/route.test.ts` — 12 tests
- `components/feedback/feedback-dialog.tsx` — Client dialog component
- `components/feedback/feedback-dialog.test.tsx` — 9 tests

## Modified Files
- `lib/constants.ts` — `FEEDBACK_CATEGORIES`
- `lib/schemas.ts` — `feedbackPayloadSchema`
- `messages/en.json` / `messages/es.json` — feedback namespace + nav/settings keys
- `components/user-menu.tsx` — "Send Feedback" menu item
- `components/settings/settings-content.tsx` — Feedback section
- `components/settings/settings-content.test.tsx` — Updated heading count
- `.env.example` — `GITHUB_FEEDBACK_TOKEN`, `GITHUB_FEEDBACK_REPO`

## Setup Required
1. Create a GitHub fine-grained PAT with `issues:write` on `Zenemig/argent`
2. Add `GITHUB_FEEDBACK_TOKEN` and `GITHUB_FEEDBACK_REPO` env vars in Vercel
3. Ensure `feedback`, `bug`, and `enhancement` labels exist in the repo

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (no new errors)
- [x] `npm test` — 911 tests pass (21 new)
- [ ] Manual: user menu → Send Feedback → submit → verify GitHub issue created

🤖 Generated with [Claude Code](https://claude.com/claude-code)