### PR TITLE
feat: add admin analytics dashboard with event tracking

### DIFF
--- a/app/(admin)/admin/loading.tsx
+++ b/app/(admin)/admin/loading.tsx
@@ -1,0 +1,49 @@
+import { Skeleton } from "@/components/ui/skeleton";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+export default function AdminLoading() {
+  return (
+    <div className="space-y-8">
+      <Skeleton className="h-8 w-40" />
+
+      {/* KPI skeletons */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        {Array.from({ length: 7 }, (_, i) => (
+          <Card key={i}>
+            <CardContent className="pt-6">
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="mt-2 h-9 w-16" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* Chart skeletons */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        {Array.from({ length: 2 }, (_, i) => (
+          <Card key={i}>
+            <CardHeader>
+              <Skeleton className="h-5 w-40" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-[260px] w-full rounded-md" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        {Array.from({ length: 2 }, (_, i) => (
+          <Card key={i}>
+            <CardHeader>
+              <Skeleton className="h-5 w-40" />
+            </CardHeader>
+            <CardContent>
+              <Skeleton className="h-[260px] w-full rounded-md" />
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/admin/page.tsx
+++ b/app/(admin)/admin/page.tsx
@@ -1,0 +1,81 @@
+import { createAdminClient } from "@/lib/supabase/admin";
+import { fetchOverviewKpis } from "@/lib/admin/queries/overview";
+import { fetchUserGrowth } from "@/lib/admin/queries/growth";
+import { fetchFunnelData } from "@/lib/admin/queries/funnel";
+import { fetchEngagementDepth } from "@/lib/admin/queries/engagement";
+import { fetchShootingTrends } from "@/lib/admin/queries/trends";
+import { KpiCard } from "@/components/admin/kpi-card";
+import { LineChartCard } from "@/components/admin/line-chart-card";
+import { BarChartCard } from "@/components/admin/bar-chart-card";
+import { FunnelChart } from "@/components/admin/funnel-chart";
+
+export const revalidate = 900; // ISR: 15 minutes
+
+export default async function AdminDashboardPage() {
+  const admin = createAdminClient();
+
+  const [kpis, growth, funnel, engagement, trends] = await Promise.all([
+    fetchOverviewKpis(admin),
+    fetchUserGrowth(admin),
+    fetchFunnelData(admin),
+    fetchEngagementDepth(admin),
+    fetchShootingTrends(admin),
+  ]);
+
+  return (
+    <div className="space-y-8">
+      <h1 className="text-2xl font-bold">Dashboard</h1>
+
+      {/* KPI cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <KpiCard label="Total Users" value={kpis.totalUsers} />
+        <KpiCard label="Pro Users" value={kpis.proUsers} />
+        <KpiCard label="Free Users" value={kpis.freeUsers} />
+        <KpiCard label="Waitlist" value={kpis.waitlistUsers} />
+        <KpiCard label="Total Rolls" value={kpis.totalRolls} />
+        <KpiCard label="Total Frames" value={kpis.totalFrames} />
+        <KpiCard label="Exports" value={kpis.totalExports} />
+      </div>
+
+      {/* Growth + Funnel */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <LineChartCard
+          title="User Growth (12 weeks)"
+          data={growth}
+          xKey="week"
+          lines={[
+            { dataKey: "signups", label: "Signups" },
+            { dataKey: "confirmations", label: "Confirmations" },
+          ]}
+        />
+        <FunnelChart title="Activation Funnel" data={funnel} />
+      </div>
+
+      {/* Engagement + Trends */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        <BarChartCard
+          title="Engagement Depth"
+          data={engagement}
+        />
+        <BarChartCard
+          title="Film Formats"
+          data={trends.filmFormats}
+          layout="vertical"
+        />
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <BarChartCard
+          title="Film Processes"
+          data={trends.filmProcesses}
+          layout="vertical"
+        />
+        <BarChartCard
+          title="Camera Types"
+          data={trends.cameraTypes}
+          layout="vertical"
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(admin)/layout.tsx
+++ b/app/(admin)/layout.tsx
@@ -1,0 +1,39 @@
+import { redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { createAdminClient } from "@/lib/supabase/admin";
+import { AdminNav } from "@/components/admin/admin-nav";
+import { signOut } from "@/app/(app)/settings/actions";
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect("/login?next=/admin");
+  }
+
+  // Check admin flag via service role (bypasses RLS)
+  const admin = createAdminClient();
+  const { data: profile } = await admin
+    .from("user_profiles")
+    .select("is_admin")
+    .eq("id", user.id)
+    .single();
+
+  if (!profile?.is_admin) {
+    redirect("/");
+  }
+
+  return (
+    <div className="min-h-screen bg-background text-foreground">
+      <AdminNav email={user.email ?? ""} signOutAction={signOut} />
+      <main className="mx-auto max-w-6xl px-4 py-8">{children}</main>
+    </div>
+  );
+}

--- a/app/(app)/settings/actions.ts
+++ b/app/(app)/settings/actions.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from "next/navigation";
 import { createClient } from "@/lib/supabase/server";
+import { trackEventServer } from "@/lib/analytics/track-event.server";
 
 export async function signOut() {
   const supabase = await createClient();
@@ -22,6 +23,8 @@ export async function joinWaitlist() {
     .upsert({ email: user.email }, { onConflict: "email" });
 
   if (error) return { error: "failed" };
+
+  await trackEventServer(supabase, user.id, "joined_waitlist");
 
   return { success: true };
 }

--- a/app/[locale]/(marketing)/page.tsx
+++ b/app/[locale]/(marketing)/page.tsx
@@ -1,11 +1,11 @@
 import { useTranslations } from "next-intl";
 import { setRequestLocale, getTranslations } from "next-intl/server";
-import { Link } from "@/i18n/navigation";
 import type { Metadata } from "next";
 import Image from "next/image";
 import { WifiOff, FileCode, Globe, FolderOpen, Check } from "lucide-react";
 import { Logo } from "@/components/logo";
 import { Reveal } from "@/components/marketing/reveal";
+import { CtaLink } from "@/components/marketing/cta-link";
 
 export async function generateMetadata({
   params,
@@ -107,12 +107,13 @@ function LandingPage({ locale }: { locale: string }) {
             {t("hero.subtitle")}
           </p>
           <div className="mt-10 flex justify-center gap-4 animate-fade-up [animation-delay:450ms]">
-            <Link
+            <CtaLink
               href="/login?mode=signup"
+              trackName="cta_hero_signup"
               className="rounded-xl bg-primary px-6 py-3 text-sm font-semibold text-primary-foreground shadow-sm transition-all duration-200 hover:bg-primary/90 hover:shadow-md hover:-translate-y-0.5 active:translate-y-0 active:scale-[0.97]"
             >
               {t("hero.cta")}
-            </Link>
+            </CtaLink>
             <a
               href="#how-it-works"
               className="rounded-xl border border-border bg-background/50 px-6 py-3 text-sm font-semibold backdrop-blur transition-all duration-200 hover:bg-accent hover:border-zinc-600 hover:-translate-y-0.5 active:translate-y-0 active:scale-[0.97]"
@@ -243,12 +244,13 @@ function LandingPage({ locale }: { locale: string }) {
                   </li>
                 ))}
               </ul>
-              <Link
+              <CtaLink
                 href="/login?mode=signup"
+                trackName="cta_pricing_free_signup"
                 className="mt-auto block rounded-xl bg-primary px-6 py-3 text-center text-sm font-semibold text-primary-foreground transition-all duration-200 hover:bg-primary/90 hover:shadow-md hover:-translate-y-0.5 active:translate-y-0 active:scale-[0.97]"
               >
                 {t("pricing.getStarted")}
-              </Link>
+              </CtaLink>
             </div>
             </Reveal>
             {/* Pro Tier */}
@@ -273,12 +275,13 @@ function LandingPage({ locale }: { locale: string }) {
                   </li>
                 ))}
               </ul>
-              <Link
+              <CtaLink
                 href="/login?mode=signup&interest=pro"
+                trackName="cta_pricing_pro_waitlist"
                 className="mt-auto block rounded-xl border border-border px-6 py-3 text-center text-sm font-semibold transition-all duration-200 hover:bg-accent hover:border-zinc-600 hover:-translate-y-0.5 active:translate-y-0 active:scale-[0.97]"
               >
                 {t("pricing.joinWaitlist")}
-              </Link>
+              </CtaLink>
             </div>
             </Reveal>
           </div>

--- a/app/api/analytics/track/route.ts
+++ b/app/api/analytics/track/route.ts
@@ -1,0 +1,46 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { trackEventPayloadSchema } from "@/lib/schemas";
+
+export async function POST(request: Request) {
+  // 1. Authenticate
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "unauthenticated" }, { status: 401 });
+  }
+
+  // 2. Parse & validate
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "invalidJson" }, { status: 400 });
+  }
+
+  const parsed = trackEventPayloadSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: "validation", details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  // 3. Insert event (unique constraint handles fire-once deduplication)
+  const { error } = await supabase.from("analytics_events").insert({
+    user_id: user.id,
+    event_name: parsed.data.event_name,
+    metadata: parsed.data.metadata ?? {},
+  });
+
+  // 23505 = unique_violation — event already recorded, still a success
+  if (error && error.code !== "23505") {
+    console.error("[analytics/track] Insert error:", error);
+    return NextResponse.json({ error: "insertFailed" }, { status: 500 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/app/auth/callback/route.test.ts
+++ b/app/auth/callback/route.test.ts
@@ -24,6 +24,10 @@ vi.mock("@/lib/email/send-welcome", () => ({
   sendWelcomeEmail: (...args: unknown[]) => mockSendWelcome(...args),
 }));
 
+vi.mock("@/lib/analytics/track-event.server", () => ({
+  trackEventServer: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("next/headers", () => ({
   cookies: () =>
     Promise.resolve({

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { sendWelcomeEmail } from "@/lib/email/send-welcome";
+import { trackEventServer } from "@/lib/analytics/track-event.server";
 import type { EmailLocale } from "@/lib/email/templates/types";
 
 export async function GET(request: Request) {
@@ -24,6 +25,8 @@ export async function GET(request: Request) {
         } = await supabase.auth.getUser();
 
         if (user && !user.user_metadata?.welcome_email_sent) {
+          await trackEventServer(supabase, user.id, "email_confirmed");
+
           const locale =
             (user.user_metadata?.locale as EmailLocale) ?? "en";
           await sendWelcomeEmail({ email: user.email!, locale });

--- a/components/admin/admin-nav.tsx
+++ b/components/admin/admin-nav.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import Link from "next/link";
+import { LogoIcon } from "@/components/logo";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+
+interface AdminNavProps {
+  email: string;
+  signOutAction: () => Promise<void>;
+}
+
+export function AdminNav({ email, signOutAction }: AdminNavProps) {
+  return (
+    <header className="sticky top-0 z-50 border-b border-border bg-background/95 backdrop-blur">
+      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4">
+        <div className="flex items-center gap-3">
+          <Link href="/admin" className="flex items-center gap-2">
+            <LogoIcon className="h-6 text-zinc-300" />
+            <Badge variant="secondary" className="text-xs">
+              Admin
+            </Badge>
+          </Link>
+        </div>
+        <div className="flex items-center gap-4">
+          <span className="hidden text-sm text-muted-foreground sm:inline">
+            {email}
+          </span>
+          <Link href="/">
+            <Button variant="ghost" size="sm">
+              App
+            </Button>
+          </Link>
+          <form action={signOutAction}>
+            <Button variant="ghost" size="sm" type="submit">
+              Sign out
+            </Button>
+          </form>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/components/admin/bar-chart-card.tsx
+++ b/components/admin/bar-chart-card.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const CHART_HEIGHT = 260;
+const BAR_COLOR = "var(--primary)";
+const GRID_COLOR = "var(--border)";
+const TEXT_COLOR = "var(--muted-foreground)";
+
+interface BarChartCardProps {
+  title: string;
+  data: { name: string; count: number }[];
+  layout?: "vertical" | "horizontal";
+}
+
+export function BarChartCard({
+  title,
+  data,
+  layout = "horizontal",
+}: BarChartCardProps) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="py-10 text-center text-sm text-muted-foreground">
+            No data yet
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+          {layout === "vertical" ? (
+            <BarChart
+              data={data}
+              layout="vertical"
+              margin={{ left: 0, right: 16, top: 0, bottom: 0 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke={GRID_COLOR}
+                horizontal={false}
+              />
+              <XAxis
+                type="number"
+                allowDecimals={false}
+                tick={{ fill: TEXT_COLOR, fontSize: 12 }}
+              />
+              <YAxis
+                type="category"
+                dataKey="name"
+                width={120}
+                tick={{ fill: TEXT_COLOR, fontSize: 12 }}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "var(--popover)",
+                  borderColor: GRID_COLOR,
+                  color: "var(--popover-foreground)",
+                  borderRadius: 8,
+                }}
+              />
+              <Bar dataKey="count" fill={BAR_COLOR} radius={[0, 4, 4, 0]} />
+            </BarChart>
+          ) : (
+            <BarChart
+              data={data}
+              margin={{ left: 0, right: 16, top: 0, bottom: 0 }}
+            >
+              <CartesianGrid
+                strokeDasharray="3 3"
+                stroke={GRID_COLOR}
+                vertical={false}
+              />
+              <XAxis
+                dataKey="name"
+                tick={{ fill: TEXT_COLOR, fontSize: 12 }}
+              />
+              <YAxis
+                allowDecimals={false}
+                tick={{ fill: TEXT_COLOR, fontSize: 12 }}
+              />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: "var(--popover)",
+                  borderColor: GRID_COLOR,
+                  color: "var(--popover-foreground)",
+                  borderRadius: 8,
+                }}
+              />
+              <Bar dataKey="count" fill={BAR_COLOR} radius={[4, 4, 0, 0]} />
+            </BarChart>
+          )}
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/funnel-chart.tsx
+++ b/components/admin/funnel-chart.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import type { FunnelStep } from "@/lib/admin/queries/funnel";
+
+interface FunnelChartProps {
+  title: string;
+  data: FunnelStep[];
+}
+
+export function FunnelChart({ title, data }: FunnelChartProps) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="py-10 text-center text-sm text-muted-foreground">
+            No data yet
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const maxCount = Math.max(...data.map((d) => d.count), 1);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {data.map((step) => (
+          <div key={step.step}>
+            <div className="mb-1 flex items-center justify-between text-sm">
+              <span className="text-muted-foreground">{step.step}</span>
+              <span className="flex items-center gap-2 tabular-nums">
+                <span className="font-medium">{step.count}</span>
+                {step.dropOff !== null && (
+                  <span className="text-xs text-muted-foreground">
+                    (-{step.dropOff}%)
+                  </span>
+                )}
+              </span>
+            </div>
+            <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+              <div
+                className="h-full rounded-full bg-primary transition-all"
+                style={{
+                  width: `${(step.count / maxCount) * 100}%`,
+                }}
+              />
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/kpi-card.tsx
+++ b/components/admin/kpi-card.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Card, CardContent } from "@/components/ui/card";
+
+interface KpiCardProps {
+  label: string;
+  value: number;
+}
+
+export function KpiCard({ label, value }: KpiCardProps) {
+  return (
+    <Card>
+      <CardContent className="pt-6">
+        <p className="text-sm text-muted-foreground">{label}</p>
+        <p className="mt-1 text-3xl font-bold tabular-nums">
+          {value.toLocaleString()}
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/admin/line-chart-card.tsx
+++ b/components/admin/line-chart-card.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+  ResponsiveContainer,
+  CartesianGrid,
+  Legend,
+} from "recharts";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+const CHART_HEIGHT = 260;
+const GRID_COLOR = "var(--border)";
+const TEXT_COLOR = "var(--muted-foreground)";
+
+const COLORS = [
+  "var(--primary)",
+  "var(--chart-2, #f59e0b)",
+  "var(--chart-3, #10b981)",
+  "var(--chart-4, #8b5cf6)",
+];
+
+interface LineConfig {
+  dataKey: string;
+  label: string;
+}
+
+interface LineChartCardProps {
+  title: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  data: Record<string, any>[];
+  xKey: string;
+  lines: LineConfig[];
+}
+
+export function LineChartCard({ title, data, xKey, lines }: LineChartCardProps) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">{title}</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="py-10 text-center text-sm text-muted-foreground">
+            No data yet
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={CHART_HEIGHT}>
+          <LineChart
+            data={data}
+            margin={{ left: 0, right: 16, top: 8, bottom: 0 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke={GRID_COLOR} />
+            <XAxis
+              dataKey={xKey}
+              tick={{ fill: TEXT_COLOR, fontSize: 12 }}
+            />
+            <YAxis
+              allowDecimals={false}
+              tick={{ fill: TEXT_COLOR, fontSize: 12 }}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: "var(--popover)",
+                borderColor: GRID_COLOR,
+                color: "var(--popover-foreground)",
+                borderRadius: 8,
+              }}
+            />
+            {lines.length > 1 && <Legend />}
+            {lines.map((line, i) => (
+              <Line
+                key={line.dataKey}
+                type="monotone"
+                dataKey={line.dataKey}
+                name={line.label}
+                stroke={COLORS[i % COLORS.length]}
+                strokeWidth={2}
+                dot={{ fill: COLORS[i % COLORS.length], r: 4 }}
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -10,6 +10,7 @@ import { LogoIcon } from "@/components/logo";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
 import { signIn, signUp, resetPassword } from "@/app/(auth)/actions";
+import { trackEvent } from "@/lib/analytics/track-event";
 
 type Mode = "login" | "signup" | "reset";
 
@@ -40,6 +41,9 @@ export function LoginForm({ defaultMode = "login", next, interest }: LoginFormPr
         toast.error(t(result.error));
       }
       if (result?.success) {
+        if (mode === "signup") {
+          trackEvent("signup_started");
+        }
         toast.success(t(result.success));
       }
     });

--- a/components/export/xmp-export-dialog.tsx
+++ b/components/export/xmp-export-dialog.tsx
@@ -4,6 +4,7 @@ import { useState, useCallback, useEffect } from "react";
 import { useTranslations } from "next-intl";
 import { Loader2 } from "lucide-react";
 import { toast } from "sonner";
+import { trackEvent } from "@/lib/analytics/track-event";
 import {
   Dialog,
   DialogContent,
@@ -303,6 +304,7 @@ export function ExportDialog({
 
       await generateAndDownload(format, inputs, options, filmLabel);
 
+      trackEvent("first_export");
       toast.success(t("success"));
       onOpenChange(false);
     } catch (error) {

--- a/components/gear/camera-form.tsx
+++ b/components/gear/camera-form.tsx
@@ -22,6 +22,7 @@ import { useUserId } from "@/hooks/useUserId";
 import type { Camera, FilmFormat, LensMount, CameraType, ShutterSpeed, MeteringMode } from "@/lib/types";
 import { useState } from "react";
 import { toast } from "sonner";
+import { trackEvent } from "@/lib/analytics/track-event";
 
 interface CameraFormProps {
   camera?: Camera;
@@ -99,6 +100,7 @@ export function CameraForm({ camera, onDone }: CameraFormProps) {
         created_at: now,
       });
       toast.success(t("cameraAdded"));
+      trackEvent("first_camera_added");
     }
 
     onDone();

--- a/components/gear/lens-form.tsx
+++ b/components/gear/lens-form.tsx
@@ -19,6 +19,7 @@ import { useUserId } from "@/hooks/useUserId";
 import type { Lens, Camera, LensMount } from "@/lib/types";
 import { useState } from "react";
 import { toast } from "sonner";
+import { trackEvent } from "@/lib/analytics/track-event";
 
 interface LensFormProps {
   lens?: Lens;
@@ -83,6 +84,7 @@ export function LensForm({ lens, cameras, onDone }: LensFormProps) {
         created_at: now,
       });
       toast.success(t("lensAdded"));
+      trackEvent("first_lens_added");
     }
 
     onDone();

--- a/components/marketing/cta-link.tsx
+++ b/components/marketing/cta-link.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+import { Link } from "@/i18n/navigation";
+import { track } from "@vercel/analytics";
+import type { ComponentProps } from "react";
+
+interface CtaLinkProps extends ComponentProps<typeof Link> {
+  trackName: string;
+}
+
+export function CtaLink({ trackName, onClick, ...props }: CtaLinkProps) {
+  return (
+    <Link
+      {...props}
+      onClick={(e) => {
+        track(trackName);
+        onClick?.(e);
+      }}
+    />
+  );
+}

--- a/components/roll/load-roll-wizard.tsx
+++ b/components/roll/load-roll-wizard.tsx
@@ -32,6 +32,7 @@ import { useUserId } from "@/hooks/useUserId";
 import { DEFAULT_FRAME_COUNTS } from "@/lib/constants";
 import type { Camera as CameraType, FilmFormat } from "@/lib/types";
 import { toast } from "sonner";
+import { trackEvent } from "@/lib/analytics/track-event";
 
 interface LoadRollWizardProps {
   open: boolean;
@@ -208,6 +209,7 @@ export function LoadRollWizard({ open, onOpenChange }: LoadRollWizardProps) {
     });
 
     toast.success(t("rollCreated"));
+    trackEvent("first_roll_loaded");
     resetAndClose();
     router.push(`/roll/${id}`);
   }

--- a/components/roll/shot-logger.tsx
+++ b/components/roll/shot-logger.tsx
@@ -37,6 +37,7 @@ import { ScrollArea } from "@/components/ui/scroll-area";
 import { db } from "@/lib/db";
 import { syncAdd, syncUpdate } from "@/lib/sync-write";
 import { toBlob } from "@/lib/image-sync";
+import { trackEvent } from "@/lib/analytics/track-event";
 import { EXPOSURE_COMP_VALUES } from "@/lib/constants";
 import {
   filterShutterSpeeds,
@@ -394,6 +395,7 @@ export function ShotLogger({ roll }: ShotLoggerProps) {
     }
 
     resetFormState();
+    trackEvent("first_frame_logged");
     toast.success(t("frameNumber", { number: nextFrameNumber }));
   }, [
     roll.id,

--- a/lib/admin/queries/engagement.ts
+++ b/lib/admin/queries/engagement.ts
@@ -1,0 +1,48 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface EngagementBucket {
+  name: string;
+  count: number;
+}
+
+export async function fetchEngagementDepth(
+  admin: SupabaseClient,
+): Promise<EngagementBucket[]> {
+  // Get roll count per user
+  const { data: rolls } = await admin
+    .from("rolls")
+    .select("user_id");
+
+  if (!rolls) return [];
+
+  // Count rolls per user
+  const userRolls = new Map<string, number>();
+  for (const row of rolls) {
+    userRolls.set(row.user_id, (userRolls.get(row.user_id) ?? 0) + 1);
+  }
+
+  // Get all users to include zero-roll users
+  const { count: totalUsers } = await admin
+    .from("user_profiles")
+    .select("*", { count: "exact", head: true });
+
+  const usersWithRolls = userRolls.size;
+  const zeroRolls = (totalUsers ?? 0) - usersWithRolls;
+
+  let oneToFive = 0;
+  let sixToTwenty = 0;
+  let twentyPlus = 0;
+
+  for (const count of userRolls.values()) {
+    if (count <= 5) oneToFive++;
+    else if (count <= 20) sixToTwenty++;
+    else twentyPlus++;
+  }
+
+  return [
+    { name: "0 rolls", count: zeroRolls },
+    { name: "1-5 rolls", count: oneToFive },
+    { name: "6-20 rolls", count: sixToTwenty },
+    { name: "20+ rolls", count: twentyPlus },
+  ];
+}

--- a/lib/admin/queries/funnel.ts
+++ b/lib/admin/queries/funnel.ts
@@ -1,0 +1,44 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface FunnelStep {
+  step: string;
+  count: number;
+  dropOff: number | null; // percentage drop from previous step, null for first
+}
+
+const FUNNEL_STEPS = [
+  { step: "Signed up", event: "signup_started" },
+  { step: "Email confirmed", event: "email_confirmed" },
+  { step: "First camera", event: "first_camera_added" },
+  { step: "First roll loaded", event: "first_roll_loaded" },
+  { step: "First frame logged", event: "first_frame_logged" },
+  { step: "First export", event: "first_export" },
+] as const;
+
+export async function fetchFunnelData(
+  admin: SupabaseClient,
+): Promise<FunnelStep[]> {
+  const counts = await Promise.all(
+    FUNNEL_STEPS.map(({ event }) =>
+      admin
+        .from("analytics_events")
+        .select("*", { count: "exact", head: true })
+        .eq("event_name", event),
+    ),
+  );
+
+  const steps: FunnelStep[] = [];
+  let prev: number | null = null;
+
+  for (let i = 0; i < FUNNEL_STEPS.length; i++) {
+    const count = counts[i].count ?? 0;
+    const dropOff =
+      prev !== null && prev > 0
+        ? Math.round(((prev - count) / prev) * 100)
+        : null;
+    steps.push({ step: FUNNEL_STEPS[i].step, count, dropOff });
+    prev = count;
+  }
+
+  return steps;
+}

--- a/lib/admin/queries/growth.ts
+++ b/lib/admin/queries/growth.ts
@@ -1,0 +1,65 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface WeeklyGrowthPoint {
+  week: string; // ISO week label, e.g. "2026-W08"
+  signups: number;
+  confirmations: number;
+}
+
+export async function fetchUserGrowth(
+  admin: SupabaseClient,
+): Promise<WeeklyGrowthPoint[]> {
+  const twelveWeeksAgo = new Date();
+  twelveWeeksAgo.setDate(twelveWeeksAgo.getDate() - 84);
+
+  const [signupsRes, confirmationsRes] = await Promise.all([
+    admin
+      .from("analytics_events")
+      .select("created_at")
+      .eq("event_name", "signup_started")
+      .gte("created_at", twelveWeeksAgo.toISOString())
+      .order("created_at", { ascending: true }),
+    admin
+      .from("analytics_events")
+      .select("created_at")
+      .eq("event_name", "email_confirmed")
+      .gte("created_at", twelveWeeksAgo.toISOString())
+      .order("created_at", { ascending: true }),
+  ]);
+
+  const signups = signupsRes.data ?? [];
+  const confirmations = confirmationsRes.data ?? [];
+
+  // Bucket by ISO week
+  const weekMap = new Map<string, { signups: number; confirmations: number }>();
+
+  for (const row of signups) {
+    const week = toIsoWeek(new Date(row.created_at));
+    const entry = weekMap.get(week) ?? { signups: 0, confirmations: 0 };
+    entry.signups++;
+    weekMap.set(week, entry);
+  }
+
+  for (const row of confirmations) {
+    const week = toIsoWeek(new Date(row.created_at));
+    const entry = weekMap.get(week) ?? { signups: 0, confirmations: 0 };
+    entry.confirmations++;
+    weekMap.set(week, entry);
+  }
+
+  return Array.from(weekMap.entries())
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([week, data]) => ({ week, ...data }));
+}
+
+function toIsoWeek(date: Date): string {
+  const d = new Date(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()),
+  );
+  d.setUTCDate(d.getUTCDate() + 4 - (d.getUTCDay() || 7));
+  const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+  const weekNo = Math.ceil(
+    ((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7,
+  );
+  return `${d.getUTCFullYear()}-W${String(weekNo).padStart(2, "0")}`;
+}

--- a/lib/admin/queries/overview.ts
+++ b/lib/admin/queries/overview.ts
@@ -1,0 +1,50 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface OverviewKpis {
+  totalUsers: number;
+  proUsers: number;
+  freeUsers: number;
+  waitlistUsers: number;
+  totalRolls: number;
+  totalFrames: number;
+  totalExports: number;
+}
+
+export async function fetchOverviewKpis(
+  admin: SupabaseClient,
+): Promise<OverviewKpis> {
+  const [
+    totalUsersRes,
+    proUsersRes,
+    waitlistRes,
+    rollsRes,
+    framesRes,
+    exportsRes,
+  ] = await Promise.all([
+    admin.from("user_profiles").select("*", { count: "exact", head: true }),
+    admin
+      .from("user_profiles")
+      .select("*", { count: "exact", head: true })
+      .eq("tier", "pro"),
+    admin.from("waitlist").select("*", { count: "exact", head: true }),
+    admin.from("rolls").select("*", { count: "exact", head: true }),
+    admin.from("frames").select("*", { count: "exact", head: true }),
+    admin
+      .from("analytics_events")
+      .select("*", { count: "exact", head: true })
+      .eq("event_name", "first_export"),
+  ]);
+
+  const totalUsers = totalUsersRes.count ?? 0;
+  const proUsers = proUsersRes.count ?? 0;
+
+  return {
+    totalUsers,
+    proUsers,
+    freeUsers: totalUsers - proUsers,
+    waitlistUsers: waitlistRes.count ?? 0,
+    totalRolls: rollsRes.count ?? 0,
+    totalFrames: framesRes.count ?? 0,
+    totalExports: exportsRes.count ?? 0,
+  };
+}

--- a/lib/admin/queries/trends.ts
+++ b/lib/admin/queries/trends.ts
@@ -1,0 +1,78 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export interface DistributionItem {
+  name: string;
+  count: number;
+}
+
+export interface ShootingTrends {
+  filmFormats: DistributionItem[];
+  filmProcesses: DistributionItem[];
+  cameraTypes: DistributionItem[];
+}
+
+export async function fetchShootingTrends(
+  admin: SupabaseClient,
+): Promise<ShootingTrends> {
+  // Fetch rolls with their camera and film details
+  const { data: rolls } = await admin
+    .from("rolls")
+    .select("camera_id, film_id");
+
+  if (!rolls || rolls.length === 0) {
+    return { filmFormats: [], filmProcesses: [], cameraTypes: [] };
+  }
+
+  // Get unique camera and film IDs
+  const cameraIds = [...new Set(rolls.map((r) => r.camera_id))];
+  const filmIds = [...new Set(rolls.map((r) => r.film_id))];
+
+  const [camerasRes, filmsRes] = await Promise.all([
+    admin.from("cameras").select("id, format, type").in("id", cameraIds),
+    admin.from("films").select("id, format, process").in("id", filmIds),
+  ]);
+
+  const cameraMap = new Map(
+    (camerasRes.data ?? []).map((c) => [c.id, c]),
+  );
+  const filmMap = new Map(
+    (filmsRes.data ?? []).map((f) => [f.id, f]),
+  );
+
+  // Count distributions
+  const formatCounts = new Map<string, number>();
+  const processCounts = new Map<string, number>();
+  const typeCounts = new Map<string, number>();
+
+  for (const roll of rolls) {
+    const camera = cameraMap.get(roll.camera_id);
+    const film = filmMap.get(roll.film_id);
+
+    if (camera?.format) {
+      formatCounts.set(
+        camera.format,
+        (formatCounts.get(camera.format) ?? 0) + 1,
+      );
+    }
+    if (camera?.type) {
+      typeCounts.set(camera.type, (typeCounts.get(camera.type) ?? 0) + 1);
+    }
+    if (film?.process) {
+      processCounts.set(
+        film.process,
+        (processCounts.get(film.process) ?? 0) + 1,
+      );
+    }
+  }
+
+  const toSorted = (map: Map<string, number>): DistributionItem[] =>
+    Array.from(map.entries())
+      .map(([name, count]) => ({ name, count }))
+      .sort((a, b) => b.count - a.count);
+
+  return {
+    filmFormats: toSorted(formatCounts),
+    filmProcesses: toSorted(processCounts),
+    cameraTypes: toSorted(typeCounts),
+  };
+}

--- a/lib/analytics/track-event.server.ts
+++ b/lib/analytics/track-event.server.ts
@@ -1,0 +1,25 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { AnalyticsEvent } from "@/lib/constants";
+
+/**
+ * Server-side analytics event tracking.
+ * Inserts directly into analytics_events table.
+ * Silently handles unique constraint violations (fire-once semantics).
+ */
+export async function trackEventServer(
+  supabase: SupabaseClient,
+  userId: string,
+  eventName: AnalyticsEvent,
+  metadata?: Record<string, unknown>,
+) {
+  const { error } = await supabase.from("analytics_events").insert({
+    user_id: userId,
+    event_name: eventName,
+    metadata: metadata ?? {},
+  });
+
+  // 23505 = unique_violation — event already recorded, expected behavior
+  if (error && error.code !== "23505") {
+    console.error("[analytics] Failed to track event:", eventName, error);
+  }
+}

--- a/lib/analytics/track-event.ts
+++ b/lib/analytics/track-event.ts
@@ -1,0 +1,18 @@
+import type { AnalyticsEvent } from "@/lib/constants";
+
+/**
+ * Fire-and-forget client-side analytics event.
+ * Silently fails if offline or the request errors.
+ */
+export function trackEvent(
+  eventName: AnalyticsEvent,
+  metadata?: Record<string, unknown>,
+) {
+  fetch("/api/analytics/track", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ event_name: eventName, metadata }),
+  }).catch(() => {
+    // Silent — analytics should never block UX
+  });
+}

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -143,6 +143,19 @@ export type SyncOperation = (typeof SYNC_OPERATIONS)[number];
 export const SYNC_STATUSES = ["pending", "in_progress", "failed"] as const;
 export type SyncStatus = (typeof SYNC_STATUSES)[number];
 
+/** Analytics events (fire-once per user) */
+export const ANALYTICS_EVENTS = [
+  "signup_started",
+  "email_confirmed",
+  "first_camera_added",
+  "first_lens_added",
+  "first_roll_loaded",
+  "first_frame_logged",
+  "first_export",
+  "joined_waitlist",
+] as const;
+export type AnalyticsEvent = (typeof ANALYTICS_EVENTS)[number];
+
 /** Syncable table names */
 export const SYNCABLE_TABLES = [
   "cameras",

--- a/lib/schemas.ts
+++ b/lib/schemas.ts
@@ -12,6 +12,7 @@ import {
   LENS_MOUNTS,
   CAMERA_TYPES,
   FEEDBACK_CATEGORIES,
+  ANALYTICS_EVENTS,
 } from "./constants";
 
 // ---------------------------------------------------------------------------
@@ -246,3 +247,14 @@ export const feedbackPayloadSchema = z.object({
 });
 
 export type FeedbackPayload = z.infer<typeof feedbackPayloadSchema>;
+
+// ---------------------------------------------------------------------------
+// Analytics Event Tracking (client → API route)
+// ---------------------------------------------------------------------------
+
+export const trackEventPayloadSchema = z.object({
+  event_name: z.enum(ANALYTICS_EVENTS),
+  metadata: z.record(z.string(), z.unknown()).optional(),
+});
+
+export type TrackEventPayload = z.infer<typeof trackEventPayloadSchema>;

--- a/supabase/migrations/20260221000000_add_admin_analytics.sql
+++ b/supabase/migrations/20260221000000_add_admin_analytics.sql
@@ -1,0 +1,40 @@
+-- Add admin flag to user_profiles
+ALTER TABLE user_profiles ADD COLUMN IF NOT EXISTS is_admin boolean NOT NULL DEFAULT false;
+
+-- Analytics events table (fire-once per user per event)
+CREATE TABLE IF NOT EXISTS analytics_events (
+  id bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  event_name text NOT NULL,
+  metadata jsonb DEFAULT '{}',
+  created_at timestamptz NOT NULL DEFAULT now()
+);
+
+-- Fire-once deduplication: one event per user per event_name
+CREATE UNIQUE INDEX IF NOT EXISTS analytics_events_user_event_uniq
+  ON analytics_events (user_id, event_name);
+
+-- Query indexes for admin dashboard
+CREATE INDEX IF NOT EXISTS analytics_events_event_created
+  ON analytics_events (event_name, created_at);
+
+CREATE INDEX IF NOT EXISTS analytics_events_user_created
+  ON analytics_events (user_id, created_at);
+
+-- Cross-user query indexes on rolls and frames
+CREATE INDEX IF NOT EXISTS rolls_user_status_idx
+  ON rolls (user_id, status);
+
+CREATE INDEX IF NOT EXISTS rolls_created_at_idx
+  ON rolls (created_at);
+
+CREATE INDEX IF NOT EXISTS frames_created_at_idx
+  ON frames (created_at);
+
+-- RLS: users can insert their own events, no SELECT (admin reads via service role)
+ALTER TABLE analytics_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users can insert own analytics events"
+  ON analytics_events FOR INSERT
+  TO authenticated
+  WITH CHECK (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- Add admin-only dashboard at `/admin` with KPI cards, user growth chart, activation funnel, engagement depth, and shooting trend distributions
- Add fire-once `analytics_events` table with `is_admin` flag on `user_profiles`
- Integrate analytics events across signup, email confirmation, gear/roll/frame creation, exports, and waitlist joins
- Add Vercel Analytics `track()` calls on marketing page CTAs

Closes #87

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (0 errors)
- [x] `npm test` — 88 files, 911 tests pass
- [x] `npm run build` — production build succeeds
- [ ] Visit `/admin` as non-admin → redirects to `/`
- [ ] Visit `/admin` as admin → shows dashboard with KPIs and charts
- [ ] Visit `/admin` unauthenticated → redirects to `/login?next=/admin`
- [ ] Click marketing CTAs → verify Vercel Analytics events
- [ ] Sign up test account → verify `signup_started` event in `analytics_events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)