### PR TITLE
fix: resolve frame timeline scrolling and form overlap on mobile

### DIFF
--- a/components/roll/shot-logger.tsx
+++ b/components/roll/shot-logger.tsx
@@ -505,8 +505,8 @@ export function ShotLogger({ roll }: ShotLoggerProps) {
       {/* Frame timeline */}
       <div className="lg:flex-1 lg:min-w-0">
       {activeFrames.length > 0 && (
-        <ScrollArea className="max-h-48 lg:max-h-[calc(100vh-16rem)]">
-          <div className="space-y-1">
+        <ScrollArea className="max-h-[calc(100dvh-12rem)] lg:max-h-[calc(100vh-16rem)]">
+          <div className={cn("space-y-1", showForm && "pb-80 lg:pb-0")}>
             {activeFrames.map((frame) => {
               const thumbUrl = frameThumbUrls.get(frame.id);
               return (


### PR DESCRIPTION
## Summary

- Use `100dvh`-based max-height on the frame timeline `ScrollArea` so it fills the available viewport on mobile (accounts for browser chrome)
- Add `pb-80` bottom padding inside the scroll content when the form panel is visible, so frames can scroll above the fixed form overlay on mobile
- Desktop layout unaffected (`lg:pb-0` removes the padding where the form is in normal flow)

## Test plan

- [x] `npm test -- components/roll/shot-logger.test.tsx` — 27 tests pass
- [x] `npm run typecheck` — no errors
- [x] `npm run lint` — no errors
- [ ] Visual test on mobile viewport: scroll through 10+ frames, all reachable
- [ ] Form panel does not overlap any frame row when scrolled to bottom
- [ ] Desktop layout unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)